### PR TITLE
fix: manually move hann window to device

### DIFF
--- a/audio_separator/separator/uvr_lib_v5/bs_roformer.py
+++ b/audio_separator/separator/uvr_lib_v5/bs_roformer.py
@@ -475,7 +475,7 @@ class BSRoformer(Module):
 
         raw_audio, batch_audio_channel_packed_shape = pack_one(raw_audio, '* t')
 
-        stft_window = self.stft_window_fn(device=device)
+        stft_window = self.stft_window_fn().to(device)
 
         stft_repr = torch.stft(raw_audio, **self.stft_kwargs, window=stft_window, return_complex=True)
         stft_repr = torch.view_as_real(stft_repr)

--- a/audio_separator/separator/uvr_lib_v5/mel_band_roformer.py
+++ b/audio_separator/separator/uvr_lib_v5/mel_band_roformer.py
@@ -407,7 +407,7 @@ class MelBandRoformer(Module):
 
         raw_audio, batch_audio_channel_packed_shape = pack_one(raw_audio, '* t')
 
-        stft_window = self.stft_window_fn(device=device)
+        stft_window = self.stft_window_fn().to(device)
 
         stft_repr = torch.stft(raw_audio, **self.stft_kwargs, window=stft_window, return_complex=True)
         stft_repr = torch.view_as_real(stft_repr)


### PR DESCRIPTION
I am making a [BS RoFormer demo](https://huggingface.co/spaces/JacobLinCool/bs-roformer) with Hugging Face ZeroGPU (some kinds of dynamic allocated A100), and it seems that the window tensor was not placed in the right locations.

After explicitly calling `.to`, the tensor goes to the correct device (from `cpu` to `cuda`).

It's weird, but it fixes the problem when using ZeroGPU.