### PR TITLE
Reducing batch_size values for the VR architecture and a minor update to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ MDX Architecture Parameters:
   --mdx_enable_denoise                                   enable denoising after separation (default: False). Example: --mdx_enable_denoise
 
 VR Architecture Parameters:
-  --vr_batch_size VR_BATCH_SIZE                          number of "batches" to process at a time. higher = more RAM, slightly faster processing (default: 4). Example: --vr_batch_size=16
+  --vr_batch_size VR_BATCH_SIZE                          number of "batches" to process at a time. higher = more RAM, slightly faster processing (default: 1). Example: --vr_batch_size=16
   --vr_window_size VR_WINDOW_SIZE                        balance quality and speed. 1024 = fast but lower, 320 = slower but better quality. (default: 512). Example: --vr_window_size=320
   --vr_aggression VR_AGGRESSION                          intensity of primary stem extraction, -100 - 100. typically 5 for vocals & instrumentals (default: 5). Example: --vr_aggression=2
   --vr_enable_tta                                        enable Test-Time-Augmentation; slow but improves quality (default: False). Example: --vr_enable_tta
@@ -235,7 +235,7 @@ import os
 from audio_separator.separator import Separator
 
 input = "/content/input.mp3"
-output = "/content/out"
+output = "/content/output"
 
 separator = Separator(output_dir=output, vr_params={"batch_size": 1})
 
@@ -313,7 +313,7 @@ output_file_paths_6 = separator.separate('audio3.wav')
 - invert_using_spec: (Optional) Flag to invert using spectrogram. Default: False
 - sample_rate: (Optional) Set the sample rate of the output audio. Default: 44100
 - mdx_params: (Optional) MDX Architecture Specific Attributes & Defaults. Default: {"hop_length": 1024, "segment_size": 256, "overlap": 0.25, "batch_size": 1}
-- vr_params: (Optional) VR Architecture Specific Attributes & Defaults. Default: {"batch_size": 16, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False}
+- vr_params: (Optional) VR Architecture Specific Attributes & Defaults. Default: {"batch_size": 1, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False}
 - demucs_params: (Optional) VR Architecture Specific Attributes & Defaults. {"segment_size": "Default", "shifts": 2, "overlap": 0.25, "segments_enabled": True}
 
 ## Requirements 📋

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ from audio_separator.separator import Separator
 input = "/content/input.mp3"
 output = "/content/output"
 
-separator = Separator(output_dir=output, vr_params={"batch_size": 1})
+separator = Separator(output_dir=output)
 
 # Vocals and Instrumental
 vocals = os.path.join(output, 'Vocals.wav')

--- a/audio_separator/separator/architectures/vr_separator.py
+++ b/audio_separator/separator/architectures/vr_separator.py
@@ -74,7 +74,7 @@ class VRSeparator(CommonSeparator):
         # - Batch size value has no effect on output quality.
 
         # Andrew note: for some reason, lower batch sizes seem to cause broken output for VR arch; need to investigate why
-        self.batch_size = arch_config.get("batch_size", 16)
+        self.batch_size = arch_config.get("batch_size", 1)
 
         # Select window size to balance quality and speed:
         # - 1024 - Quick but lesser quality.

--- a/audio_separator/separator/separator.py
+++ b/audio_separator/separator/separator.py
@@ -75,7 +75,7 @@ class Separator:
         invert_using_spec=False,
         sample_rate=44100,
         mdx_params={"hop_length": 1024, "segment_size": 256, "overlap": 0.25, "batch_size": 1, "enable_denoise": False},
-        vr_params={"batch_size": 16, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False},
+        vr_params={"batch_size": 1, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False},
         demucs_params={"segment_size": "Default", "shifts": 2, "overlap": 0.25, "segments_enabled": True},
         mdxc_params={"segment_size": 256, "batch_size": 1, "overlap": 8},
     ):

--- a/audio_separator/utils/cli.py
+++ b/audio_separator/utils/cli.py
@@ -82,7 +82,7 @@ def main():
     vr_post_process_threshold_help = "threshold for post_process feature: 0.1-0.3 (default: %(default)s). Example: --vr_post_process_threshold=0.1"
 
     vr_params = parser.add_argument_group("VR Architecture Parameters")
-    vr_params.add_argument("--vr_batch_size", type=int, default=4, help=vr_batch_size_help)
+    vr_params.add_argument("--vr_batch_size", type=int, default=1, help=vr_batch_size_help)
     vr_params.add_argument("--vr_window_size", type=int, default=512, help=vr_window_size_help)
     vr_params.add_argument("--vr_aggression", type=int, default=5, help=vr_aggression_help)
     vr_params.add_argument("--vr_enable_tta", action="store_true", help=vr_enable_tta_help)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,7 +21,7 @@ def common_expected_args():
         "invert_using_spec": False,
         "sample_rate": 44100,
         "mdx_params": {"hop_length": 1024, "segment_size": 256, "overlap": 0.25, "batch_size": 1, "enable_denoise": False},
-        "vr_params": {"batch_size": 4, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False},
+        "vr_params": {"batch_size": 1, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False},
         "demucs_params": {"segment_size": "Default", "shifts": 2, "overlap": 0.25, "segments_enabled": True},
         "mdxc_params": {"segment_size": 256, "batch_size": 1, "overlap": 8, "override_model_segment_size": False, "pitch_shift": 0},
     }


### PR DESCRIPTION
By default, the batch_size parameter for VR models is set to 16, which can cause GPU overload (reaching 100% usage) and errors related to insufficient video memory. Reducing this value resolves the issue and simplifies the use of the model. Now, there is no need to specify the parameter `vr_params={"batch_size": 1}`.

I have tested this on my local machine, and it works perfectly (but you can verify it yourself 🙂).