### PR TITLE
2 new models and minor fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ You can also rename specific stems:
 - **`output_dir`:** (Optional) Directory where the separated files will be saved. If not specified, uses the current directory.
 - **`output_format`:** (Optional) Format to encode output files, any common format (WAV, MP3, FLAC, M4A, etc.). `Default: WAV`
 - **`normalization_threshold`:** (Optional) The amount by which the amplitude of the output audio will be multiplied. `Default: 0.9`
-- **`amplification_threshold`:** (Optional) The minimum amplitude level at which the waveform will be amplified. If the peak amplitude of the audio is below this threshold, the waveform will be scaled up to meet it. `Default: 0.6`
+- **`amplification_threshold`:** (Optional) The minimum amplitude level at which the waveform will be amplified. If the peak amplitude of the audio is below this threshold, the waveform will be scaled up to meet it. `Default: 0.0`
 - **`output_single_stem`:** (Optional) Output only a single stem, such as 'Instrumental' and 'Vocals'. `Default: None`
 - **`invert_using_spec`:** (Optional) Flag to invert using spectrogram. `Default: False`
 - **`sample_rate`:** (Optional) Set the sample rate of the output audio. `Default: 44100`

--- a/audio_separator/models.json
+++ b/audio_separator/models.json
@@ -17,6 +17,12 @@
         },
         "Roformer Model: BS-Roformer-De-Reverb": {
             "deverb_bs_roformer_8_384dim_10depth.ckpt": "deverb_bs_roformer_8_384dim_10depth_config.yaml"
+        },
+        "Roformer Model: Mel-Roformer-Vocals-Kim": {
+            "vocals_mel_band_roformer.ckpt": "vocals_mel_band_roformer.yaml"
+        },
+        "Roformer Model:  MelBand Roformer Kim | Inst V1 (E) by Unwa": {
+            "melband_roformer_inst_v1e.ckpt": "config_melbandroformer_inst.yaml"
         }
     }
 }

--- a/audio_separator/separator/separator.py
+++ b/audio_separator/separator/separator.py
@@ -420,6 +420,7 @@ class Separator:
                 **model_downloads_list["mdx23c_download_list"],
                 **model_downloads_list["mdx23c_download_vip_list"],
                 **model_downloads_list["roformer_download_list"],
+                **audio_separator_models_list["mdx23c_download_list"],
                 **audio_separator_models_list["roformer_download_list"],
             },
         }


### PR DESCRIPTION
## Models: 
### **Mel Band Roformer Vocal by Kimberley Jensen**

SDR Vocals: 11.01
SDR Instrumental: 17.32

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/vocals_mel_band_roformer.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/vocals_mel_band_roformer.yaml)

The [original](https://github.com/KimberleyJensen/Mel-Band-Roformer-Vocal-Model) config file doesn't work, so I found one that does work.

### **MelBand Roformer Kim | Inst V1 (E) by Unwa**

SDR Instrumental: 16.36
SDR Other: 10.05

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/melband_roformer_inst_v1e.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_melbandroformer_inst.yaml) yep same file as MelBand Roformer Kim | Inst V1 by Unwa

_Note: Max instrum fullness, but a bit noisy_
(E) means Emphasis, the e models by unwa emphasize the fullness metric and thus have the highest score in that metric.

_Both models were tested on Windows 11 and Ubuntu 24.04, but only with CPU as I don't have a GPU. I hope they work well with GPU and on MacOS._

## README fix: 
Just a minor fix to the default amplification_threshold value, the default value is now 0.0.