### PR TITLE
new models of various architectures

### DIFF
--- a/audio_separator/models.json
+++ b/audio_separator/models.json
@@ -1,7 +1,11 @@
 {
-    "vr_download_list": {},
+    "vr_download_list": {
+        "VR Arch Single Model v4: UVR-De-Reverb by aufr33-jarredou": "UVR-De-Reverb-aufr33-jarredou.pth"
+    },
     "mdx_download_list": {},
-    "mdx23c_download_list": {},
+    "mdx23c_download_list": {
+        "MDX23C Model: MDX23C De-Reverb by aufr33-jarredou": {"MDX23C-De-Reverb-aufr33-jarredou.ckpt":"config_dereverb_mdx23c.yaml"}
+    },
     "roformer_download_list": {
         "Roformer Model: Mel-Roformer-Karaoke-Aufr33-Viperx": {
             "mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt": "mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956_config.yaml"
@@ -18,11 +22,59 @@
         "Roformer Model: BS-Roformer-De-Reverb": {
             "deverb_bs_roformer_8_384dim_10depth.ckpt": "deverb_bs_roformer_8_384dim_10depth_config.yaml"
         },
-        "Roformer Model: Mel-Roformer-Vocals-Kim": {
+        "Roformer Model: MelBand Roformer | Vocals by Kimberley Jensen": {
             "vocals_mel_band_roformer.ckpt": "vocals_mel_band_roformer.yaml"
         },
-        "Roformer Model:  MelBand Roformer Kim | Inst V1 (E) by Unwa": {
+        "Roformer Model: MelBand Roformer Kim | FT by unwa": {
+            "mel_band_roformer_kim_ft_unwa.ckpt": "config_mel_band_roformer_kim_ft_unwa.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | Inst V1 (E) by Unwa": {
             "melband_roformer_inst_v1e.ckpt": "config_melbandroformer_inst.yaml"
+        },
+        "Roformer Model: MelBand Roformer | De-Reverb by anvuew": {
+            "dereverb_mel_band_roformer_anvuew_sdr_19.1729.ckpt": "dereverb_mel_band_roformer_anvuew.yaml"
+        },
+        "Roformer Model: MelBand Roformer | De-Reverb Less Aggressive by anvuew": {
+            "dereverb_mel_band_roformer_less_aggressive_anvuew_sdr_18.8050.ckpt": "dereverb_mel_band_roformer_anvuew.yaml"
+        },
+        "Roformer Model: MelBand Roformer | De-Reverb-Echo by Sucial": {
+            "dereverb-echo_mel_band_roformer_sdr_10.0169.ckpt": "config_dereverb-echo_mel_band_roformer.yaml"
+        },
+        "Roformer Model: MelBand Roformer | De-Reverb-Echo V2 by Sucial": {
+            "dereverb-echo_mel_band_roformer_sdr_13.4843_v2.ckpt": "config_dereverb-echo_mel_band_roformer_sdr_13.4843_v2.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | SYHFT by SYH99999": {
+            "MelBandRoformerSYHFT.ckpt": "config_vocals_mel_band_roformer_ft.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | SYHFT V2 by SYH99999": {
+            "MelBandRoformerSYHFTV2.ckpt": "config_vocals_mel_band_roformer_ft.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | SYHFT V2.5 by SYH99999": {
+            "MelBandRoformerSYHFTV2.5.ckpt": "config_vocals_mel_band_roformer_ft.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | SYHFT V3 by SYH99999": {
+            "MelBandRoformerSYHFTV3Epsilon.ckpt": "config_vocals_mel_band_roformer_ft.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | Big SYHFT V1 by SYH99999": {
+            "MelBandRoformerBigSYHFTV1.ckpt": "config_vocals_mel_band_roformer_big_v1_ft.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | Big Beta 4 FT by unwa": {
+            "melband_roformer_big_beta4.ckpt": "config_melbandroformer_big_beta4.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | Big Beta 5e FT by unwa": {
+            "melband_roformer_big_beta5e.ckpt": "config_melband_roformer_big_beta5e.yaml"
+        },
+        "Roformer Model: BS Roformer | Chorus Male-Female by Sucial": {
+            "model_chorus_bs_roformer_ep_267_sdr_24.1275.ckpt": "config_chorus_male_female_bs_roformer.yaml"
+        },
+        "Roformer Model: MelBand Roformer | Aspiration by Sucial": {
+            "aspiration_mel_band_roformer_sdr_18.9845.ckpt": "config_aspiration_mel_band_roformer.yaml"
+        },
+        "Roformer Model: MelBand Roformer | Aspiration Less Aggressive by Sucial": {
+            "aspiration_mel_band_roformer_less_aggr_sdr_18.1201.ckpt": "config_aspiration_mel_band_roformer.yaml"
+        },
+        "Roformer Model: MelBand Roformer | Bleed Suppressor V1 by unwa-97chris": {
+            "mel_band_roformer_bleed_suppressor_v1.ckpt": "config_mel_band_roformer_bleed_suppressor_v1.yaml"
         }
     }
 }

--- a/audio_separator/separator/uvr_lib_v5/vr_network/modelparams/4band_v4_ms_fullband.json
+++ b/audio_separator/separator/uvr_lib_v5/vr_network/modelparams/4band_v4_ms_fullband.json
@@ -1,0 +1,58 @@
+{
+    "n_bins": 896,
+    "unstable_bins": 9,
+    "stable_bins": 530,
+    "band": {
+        "1": {
+            "sr": 7350,
+            "hl": 96,
+            "n_fft": 768,
+            "crop_start": 0,
+            "crop_stop": 102,
+            "lpf_start": 30,
+            "lpf_stop": 62,
+            "res_type": "polyphase",
+            "convert_channels": "mid_side"
+        },
+        "2": {
+            "sr": 7350,
+            "hl": 96,
+            "n_fft": 384,
+            "crop_start": 5,
+            "crop_stop": 104,
+            "hpf_start": 30,
+            "hpf_stop": 14,
+            "lpf_start": 37,
+            "lpf_stop": 73,
+            "res_type": "polyphase",
+			"convert_channels": "mid_side"
+        },
+        "3": {
+            "sr": 14700,
+            "hl": 192,
+            "n_fft": 640,
+            "crop_start": 20,
+            "crop_stop": 259,
+            "hpf_start": 58,
+            "hpf_stop": 29,
+            "lpf_start": 191,
+            "lpf_stop": 262,
+            "res_type": "polyphase",
+			"convert_channels": "mid_side"
+        },
+        "4": {
+            "sr": 44100,
+            "hl": 576,
+            "n_fft": 1152,
+            "crop_start": 119,
+            "crop_stop": 575,
+            "hpf_start": 157,
+            "hpf_stop": 110,
+            "res_type": "kaiser_fast",
+			"convert_channels": "mid_side"
+        }
+    },
+    "sr": 44100,
+    "pre_filter_start": -1,
+    "pre_filter_stop": -1
+}


### PR DESCRIPTION
# Models: 
## Roformers:
### **MelBand Roformer Kim | FT by unwa**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/mel_band_roformer_kim_ft_unwa.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_mel_band_roformer_kim_ft_unwa.yaml)

### **MelBand Roformer | De-Reverb by anvuew**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/dereverb_mel_band_roformer_anvuew_sdr_19.1729.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/dereverb_mel_band_roformer_anvuew.yaml)

### **MelBand Roformer | De-Reverb Less Aggressive by anvuew**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/dereverb_mel_band_roformer_less_aggressive_anvuew_sdr_18.8050.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/dereverb_mel_band_roformer_anvuew.yaml)

### **MelBand Roformer | De-Reverb-Echo by Sucial**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/dereverb-echo_mel_band_roformer_sdr_10.0169.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_dereverb-echo_mel_band_roformer.yaml)

### **MelBand Roformer | De-Reverb-Echo V2 by Sucial**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/dereverb-echo_mel_band_roformer_sdr_13.4843_v2.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_dereverb-echo_mel_band_roformer_sdr_13.4843_v2.yaml)

### **MelBand Roformer Kim | SYHFT by SYH99999**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/MelBandRoformerSYHFT.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_vocals_mel_band_roformer_ft.yaml)

### **MelBand Roformer Kim | SYHFT V2 by SYH99999**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/MelBandRoformerSYHFTV2.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_vocals_mel_band_roformer_ft.yaml)

### **MelBand Roformer Kim | SYHFT V2.5 by SYH99999**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/MelBandRoformerSYHFTV2.5.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_vocals_mel_band_roformer_ft.yaml)

### **MelBand Roformer Kim | SYHFT V3 by SYH99999**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/MelBandRoformerSYHFTV3Epsilon.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_vocals_mel_band_roformer_ft.yaml)

### **MelBand Roformer Kim | Big SYHFT V1 by SYH99999**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/MelBandRoformerBigSYHFTV1.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_vocals_mel_band_roformer_big_v1_ft.yaml)

### **MelBand Roformer Kim | Big Beta 4 FT by unwa**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/melband_roformer_big_beta4.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_melbandroformer_big_beta4.yaml)

### **MelBand Roformer Kim | Big Beta 5e FT by unwa**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/melband_roformer_big_beta5e.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_melband_roformer_big_beta5e.yaml)

### **BS Roformer | Chorus Male-Female by Sucial**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/model_chorus_bs_roformer_ep_267_sdr_24.1275.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_chorus_male_female_bs_roformer.yaml)

### **MelBand Roformer | Aspiration by Sucial**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/aspiration_mel_band_roformer_sdr_18.9845.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_aspiration_mel_band_roformer.yaml)

### **MelBand Roformer | Aspiration Less Aggressive by Sucial**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/aspiration_mel_band_roformer_less_aggr_sdr_18.1201.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_aspiration_mel_band_roformer.yaml)

### **MelBand Roformer | Bleed Suppressor V1 by unwa & 97chris**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/mel_band_roformer_bleed_suppressor_v1.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_mel_band_roformer_bleed_suppressor_v1.yaml)

## MDX23C:

### **MDX23C De-Reverb by aufr33 & jarredou**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/MDX23C-De-Reverb-aufr33-jarredou.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_dereverb_mdx23c.yaml)

## VR Arch:

### **UVR-De-Reverb by aufr33 & jarredou**

Checkpoint Link: [pth](https://github.com/Eddycrack864/models_test/releases/download/model-configs/UVR-De-Reverb-aufr33-jarredou.pth)
JSON Config: (In PR)
Code to be added to [model_data_new.json](https://github.com/Eddycrack864/application_data/blob/main/vr_model_data/model_data_new.json) as i said in https://github.com/nomadkaraoke/python-audio-separator/issues/166#issuecomment-2543309965:
```
"97dc361a7a88b2c4542f68364b32c7f6": {
        "vr_model_param": "4band_v4_ms_fullband",
        "primary_stem": "Dry",
        "nout": 32,
        "nout_lstm": 128,
        "is_karaoke": false,
        "is_bv_model": false,
        "is_bv_model_rebalanced": 0.0
    }
```

## Another changes

I also renamed an existing model to give credit to its author.

_These models were tested on my Windows 11 with CPU end. If you find any error lmk as I may have made some oppsie._