### PR TITLE
Begin adding evaluation scores for all models, initially MUSEDB18 + model fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 *.wav
 *.flac
 *.mp3
+tests/model-metrics/results
+tests/model-metrics/datasets
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/audio_separator/model-data.json
+++ b/audio_separator/model-data.json
@@ -1,0 +1,14 @@
+{
+    "vr_model_data": {
+        "97dc361a7a88b2c4542f68364b32c7f6": {
+            "vr_model_param": "4band_v4_ms_fullband",
+            "primary_stem": "Dry",
+            "nout": 32,
+            "nout_lstm": 128,
+            "is_karaoke": false,
+            "is_bv_model": false,
+            "is_bv_model_rebalanced": 0.0
+        }
+    },
+    "mdx_model_data": {}
+}

--- a/audio_separator/models-scores.json
+++ b/audio_separator/models-scores.json
@@ -11,11 +11,2034 @@
             "SAR": 10.1785,
             "ISR": 15.0739
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.7431,
             "SIR": 20.9606,
             "SAR": 17.3032,
             "ISR": 29.0623
+          }
+        }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.24871,
+            "SIR": 15.4624,
+            "SAR": 4.83391,
+            "ISR": 8.8857
+          },
+          "accompaniment": {
+            "SDR": 14.8927,
+            "SIR": 19.3158,
+            "SAR": 18.24,
+            "ISR": 18.8107
+          }
+        }
+      },
+      {
+        "track_name": "ANiMAL - Clinic A",
+        "scores": {
+          "vocals": {
+            "SDR": 5.43096,
+            "SIR": 12.0094,
+            "SAR": 5.75084,
+            "ISR": 12.7187
+          },
+          "accompaniment": {
+            "SDR": 10.6068,
+            "SIR": 18.0944,
+            "SAR": 12.3348,
+            "ISR": 14.9249
+          }
+        }
+      },
+      {
+        "track_name": "ANiMAL - Easy Tiger",
+        "scores": {
+          "vocals": {
+            "SDR": 8.37912,
+            "SIR": 18.9104,
+            "SAR": 8.54122,
+            "ISR": 15.3526
+          },
+          "accompaniment": {
+            "SDR": 15.3357,
+            "SIR": 21.73,
+            "SAR": 16.6099,
+            "ISR": 21.9107
+          }
+        }
+      },
+      {
+        "track_name": "ANiMAL - Rockshow",
+        "scores": {
+          "vocals": {
+            "SDR": 2.68601,
+            "SIR": 5.35433,
+            "SAR": 4.00494,
+            "ISR": 12.7504
+          },
+          "accompaniment": {
+            "SDR": 11.3974,
+            "SIR": 21.6121,
+            "SAR": 13.2817,
+            "ISR": 15.9813
+          }
+        }
+      },
+      {
+        "track_name": "Actions - Devil's Words",
+        "scores": {
+          "vocals": {
+            "SDR": 9.77937,
+            "SIR": 20.2537,
+            "SAR": 9.60245,
+            "ISR": 13.3208
+          },
+          "accompaniment": {
+            "SDR": 12.781,
+            "SIR": 15.3895,
+            "SAR": 13.3742,
+            "ISR": 23.1482
+          }
+        }
+      },
+      {
+        "track_name": "Actions - One Minute Smile",
+        "scores": {
+          "vocals": {
+            "SDR": 8.84219,
+            "SIR": 16.1098,
+            "SAR": 9.47788,
+            "ISR": 13.4743
+          },
+          "accompaniment": {
+            "SDR": 11.0084,
+            "SIR": 15.7127,
+            "SAR": 12.9399,
+            "ISR": 19.7754
+          }
+        }
+      },
+      {
+        "track_name": "Actions - South Of The Water",
+        "scores": {
+          "vocals": {
+            "SDR": 9.73747,
+            "SIR": 18.9403,
+            "SAR": 10.333,
+            "ISR": 14.4066
+          },
+          "accompaniment": {
+            "SDR": 14.318,
+            "SIR": 18.8837,
+            "SAR": 15.8694,
+            "ISR": 22.3595
+          }
+        }
+      },
+      {
+        "track_name": "Aimee Norwich - Child",
+        "scores": {
+          "vocals": {
+            "SDR": 5.91892,
+            "SIR": 20.3204,
+            "SAR": 5.93576,
+            "ISR": 10.5446
+          },
+          "accompaniment": {
+            "SDR": 17.9788,
+            "SIR": 23.2555,
+            "SAR": 21.5719,
+            "ISR": 21.9236
+          }
+        }
+      },
+      {
+        "track_name": "Alexander Ross - Goodbye Bolero",
+        "scores": {
+          "vocals": {
+            "SDR": 9.15237,
+            "SIR": 25.8856,
+            "SAR": 9.99461,
+            "ISR": 12.9868
+          },
+          "accompaniment": {
+            "SDR": 12.4142,
+            "SIR": 16.693,
+            "SAR": 15.1214,
+            "ISR": 18.7991
+          }
+        }
+      },
+      {
+        "track_name": "Alexander Ross - Velvet Curtain",
+        "scores": {
+          "vocals": {
+            "SDR": 9.03781,
+            "SIR": 18.0127,
+            "SAR": 7.57484,
+            "ISR": 10.4891
+          },
+          "accompaniment": {
+            "SDR": 13.3057,
+            "SIR": 14.2951,
+            "SAR": 13.8743,
+            "ISR": 24.6434
+          }
+        }
+      },
+      {
+        "track_name": "Angela Thomas Wade - Milk Cow Blues",
+        "scores": {
+          "vocals": {
+            "SDR": 10.2091,
+            "SIR": 23.0624,
+            "SAR": 10.6547,
+            "ISR": 17.3402
+          },
+          "accompaniment": {
+            "SDR": 13.2878,
+            "SIR": 20.8786,
+            "SAR": 14.4586,
+            "ISR": 22.0027
+          }
+        }
+      },
+      {
+        "track_name": "Atlantis Bound - It Was My Fault For Waiting",
+        "scores": {
+          "vocals": {
+            "SDR": 10.0986,
+            "SIR": 20.6672,
+            "SAR": 9.75169,
+            "ISR": 15.2152
+          },
+          "accompaniment": {
+            "SDR": 14.9512,
+            "SIR": 21.3993,
+            "SAR": 16.138,
+            "ISR": 27.0006
+          }
+        }
+      },
+      {
+        "track_name": "Auctioneer - Our Future Faces",
+        "scores": {
+          "vocals": {
+            "SDR": 6.76939,
+            "SIR": 17.5586,
+            "SAR": 6.98892,
+            "ISR": 12.3147
+          },
+          "accompaniment": {
+            "SDR": 14.8124,
+            "SIR": 20.1259,
+            "SAR": 15.7944,
+            "ISR": 24.8105
+          }
+        }
+      },
+      {
+        "track_name": "AvaLuna - Waterduct",
+        "scores": {
+          "vocals": {
+            "SDR": 7.43502,
+            "SIR": 18.5542,
+            "SAR": 7.8475,
+            "ISR": 13.134
+          },
+          "accompaniment": {
+            "SDR": 15.5321,
+            "SIR": 20.5767,
+            "SAR": 16.245,
+            "ISR": 18.7807
+          }
+        }
+      },
+      {
+        "track_name": "BigTroubles - Phantom",
+        "scores": {
+          "vocals": {
+            "SDR": 3.57991,
+            "SIR": 16.4946,
+            "SAR": 3.3243,
+            "ISR": 7.31346
+          },
+          "accompaniment": {
+            "SDR": 14.8819,
+            "SIR": 17.3794,
+            "SAR": 18.4389,
+            "ISR": 29.5074
+          }
+        }
+      },
+      {
+        "track_name": "Bill Chudziak - Children Of No-one",
+        "scores": {
+          "vocals": {
+            "SDR": 8.2519,
+            "SIR": 19.1926,
+            "SAR": 8.72244,
+            "ISR": 14.1103
+          },
+          "accompaniment": {
+            "SDR": 13.3555,
+            "SIR": 18.9906,
+            "SAR": 15.1787,
+            "ISR": 19.5638
+          }
+        }
+      },
+      {
+        "track_name": "Black Bloc - If You Want Success",
+        "scores": {
+          "vocals": {
+            "SDR": 6.89595,
+            "SIR": 22.4832,
+            "SAR": 6.83054,
+            "ISR": 10.5802
+          },
+          "accompaniment": {
+            "SDR": 13.7255,
+            "SIR": 17.3371,
+            "SAR": 16.0628,
+            "ISR": 21.1358
+          }
+        }
+      },
+      {
+        "track_name": "Celestial Shore - Die For Us",
+        "scores": {
+          "vocals": {
+            "SDR": -20.544,
+            "SIR": -37.706,
+            "SAR": 0.60976,
+            "ISR": 0.2973
+          },
+          "accompaniment": {
+            "SDR": 11.6498,
+            "SIR": 49.0042,
+            "SAR": 12.4641,
+            "ISR": 16.1127
+          }
+        }
+      },
+      {
+        "track_name": "Chris Durban - Celebrate",
+        "scores": {
+          "vocals": {
+            "SDR": 6.08146,
+            "SIR": 15.5686,
+            "SAR": 5.40936,
+            "ISR": 8.49432
+          },
+          "accompaniment": {
+            "SDR": 16.2047,
+            "SIR": 17.0075,
+            "SAR": 16.996,
+            "ISR": 26.9043
+          }
+        }
+      },
+      {
+        "track_name": "Clara Berry And Wooldog - Air Traffic",
+        "scores": {
+          "vocals": {
+            "SDR": 8.09982,
+            "SIR": 18.5838,
+            "SAR": 8.74048,
+            "ISR": 13.0896
+          },
+          "accompaniment": {
+            "SDR": 13.9941,
+            "SIR": 19.1888,
+            "SAR": 16.7467,
+            "ISR": 19.5069
+          }
+        }
+      },
+      {
+        "track_name": "Clara Berry And Wooldog - Stella",
+        "scores": {
+          "vocals": {
+            "SDR": 8.99043,
+            "SIR": 18.7958,
+            "SAR": 9.75759,
+            "ISR": 14.2486
+          },
+          "accompaniment": {
+            "SDR": 18.8229,
+            "SIR": 25.0371,
+            "SAR": 19.7476,
+            "ISR": 27.6669
+          }
+        }
+      },
+      {
+        "track_name": "Clara Berry And Wooldog - Waltz For My Victims",
+        "scores": {
+          "vocals": {
+            "SDR": 5.56311,
+            "SIR": 18.1942,
+            "SAR": 6.0561,
+            "ISR": 11.368
+          },
+          "accompaniment": {
+            "SDR": 12.8085,
+            "SIR": 17.9619,
+            "SAR": 15.7333,
+            "ISR": 18.1057
+          }
+        }
+      },
+      {
+        "track_name": "Cnoc An Tursa - Bannockburn",
+        "scores": {
+          "vocals": {
+            "SDR": 3.47258,
+            "SIR": 13.2462,
+            "SAR": 3.17736,
+            "ISR": 5.63786
+          },
+          "accompaniment": {
+            "SDR": 10.3255,
+            "SIR": 12.4029,
+            "SAR": 15.0933,
+            "ISR": 19.4058
+          }
+        }
+      },
+      {
+        "track_name": "Creepoid - OldTree",
+        "scores": {
+          "vocals": {
+            "SDR": 5.18906,
+            "SIR": 22.5721,
+            "SAR": 5.73903,
+            "ISR": 9.24557
+          },
+          "accompaniment": {
+            "SDR": 14.975,
+            "SIR": 19.4188,
+            "SAR": 17.948,
+            "ISR": 18.9743
+          }
+        }
+      },
+      {
+        "track_name": "Dark Ride - Burning Bridges",
+        "scores": {
+          "vocals": {
+            "SDR": 6.18507,
+            "SIR": 16.4992,
+            "SAR": 6.30036,
+            "ISR": 10.0651
+          },
+          "accompaniment": {
+            "SDR": 14.1405,
+            "SIR": 18.0741,
+            "SAR": 16.8313,
+            "ISR": 26.3192
+          }
+        }
+      },
+      {
+        "track_name": "Dreamers Of The Ghetto - Heavy Love",
+        "scores": {
+          "vocals": {
+            "SDR": 7.5812,
+            "SIR": 16.1195,
+            "SAR": 7.46711,
+            "ISR": 13.4299
+          },
+          "accompaniment": {
+            "SDR": 14.0101,
+            "SIR": 18.3,
+            "SAR": 14.5392,
+            "ISR": 21.4193
+          }
+        }
+      },
+      {
+        "track_name": "Drumtracks - Ghost Bitch",
+        "scores": {
+          "vocals": {
+            "SDR": 7.76299,
+            "SIR": 18.7505,
+            "SAR": 8.23403,
+            "ISR": 11.5089
+          },
+          "accompaniment": {
+            "SDR": 9.76063,
+            "SIR": 13.0942,
+            "SAR": 11.6006,
+            "ISR": 21.6246
+          }
+        }
+      },
+      {
+        "track_name": "Faces On Film - Waiting For Ga",
+        "scores": {
+          "vocals": {
+            "SDR": 4.71433,
+            "SIR": 14.0367,
+            "SAR": 3.94581,
+            "ISR": 8.26944
+          },
+          "accompaniment": {
+            "SDR": 10.3109,
+            "SIR": 12.6439,
+            "SAR": 12.5739,
+            "ISR": 21.6968
+          }
+        }
+      },
+      {
+        "track_name": "Fergessen - Back From The Start",
+        "scores": {
+          "vocals": {
+            "SDR": 8.12746,
+            "SIR": 21.5389,
+            "SAR": 9.30687,
+            "ISR": 13.3151
+          },
+          "accompaniment": {
+            "SDR": 12.8668,
+            "SIR": 18.001,
+            "SAR": 15.5456,
+            "ISR": 17.7115
+          }
+        }
+      },
+      {
+        "track_name": "Fergessen - Nos Palpitants",
+        "scores": {
+          "vocals": {
+            "SDR": 11.7225,
+            "SIR": 22.8344,
+            "SAR": 10.58,
+            "ISR": 13.4283
+          },
+          "accompaniment": {
+            "SDR": 11.5839,
+            "SIR": 13.1001,
+            "SAR": 10.4395,
+            "ISR": 23.6291
+          }
+        }
+      },
+      {
+        "track_name": "Fergessen - The Wind",
+        "scores": {
+          "vocals": {
+            "SDR": 9.20913,
+            "SIR": 19.282,
+            "SAR": 10.0456,
+            "ISR": 13.8778
+          },
+          "accompaniment": {
+            "SDR": 11.7055,
+            "SIR": 16.7757,
+            "SAR": 13.7724,
+            "ISR": 16.9293
+          }
+        }
+      },
+      {
+        "track_name": "Flags - 54",
+        "scores": {
+          "vocals": {
+            "SDR": 10.1419,
+            "SIR": 30.1871,
+            "SAR": 10.9111,
+            "ISR": 15.3985
+          },
+          "accompaniment": {
+            "SDR": 16.1001,
+            "SIR": 22.8839,
+            "SAR": 19.7081,
+            "ISR": 19.6091
+          }
+        }
+      },
+      {
+        "track_name": "Giselle - Moss",
+        "scores": {
+          "vocals": {
+            "SDR": 1.88926,
+            "SIR": 8.76664,
+            "SAR": 4.81204,
+            "ISR": 8.86849
+          },
+          "accompaniment": {
+            "SDR": 9.9125,
+            "SIR": 14.02,
+            "SAR": 12.4588,
+            "ISR": 16.7232
+          }
+        }
+      },
+      {
+        "track_name": "Grants - PunchDrunk",
+        "scores": {
+          "vocals": {
+            "SDR": 12.4278,
+            "SIR": 24.0343,
+            "SAR": 12.6541,
+            "ISR": 21.4862
+          },
+          "accompaniment": {
+            "SDR": 20.8791,
+            "SIR": 29.5482,
+            "SAR": 21.5446,
+            "ISR": 27.4235
+          }
+        }
+      },
+      {
+        "track_name": "Helado Negro - Mitad Del Mundo",
+        "scores": {
+          "vocals": {
+            "SDR": 10.1582,
+            "SIR": 19.0278,
+            "SAR": 11.3987,
+            "ISR": 18.4367
+          },
+          "accompaniment": {
+            "SDR": 10.827,
+            "SIR": 17.4836,
+            "SAR": 11.1509,
+            "ISR": 18.6054
+          }
+        }
+      },
+      {
+        "track_name": "Hezekiah Jones - Borrowed Heart",
+        "scores": {
+          "vocals": {
+            "SDR": 6.23827,
+            "SIR": 17.2753,
+            "SAR": 6.55888,
+            "ISR": 10.6605
+          },
+          "accompaniment": {
+            "SDR": 11.4443,
+            "SIR": 15.754,
+            "SAR": 13.6843,
+            "ISR": 24.0501
+          }
+        }
+      },
+      {
+        "track_name": "Hollow Ground - Left Blind",
+        "scores": {
+          "vocals": {
+            "SDR": 5.15022,
+            "SIR": 12.9594,
+            "SAR": 5.2702,
+            "ISR": 12.1
+          },
+          "accompaniment": {
+            "SDR": 14.2903,
+            "SIR": 22.4148,
+            "SAR": 17.1974,
+            "ISR": 18.2176
+          }
+        }
+      },
+      {
+        "track_name": "Hop Along - Sister Cities",
+        "scores": {
+          "vocals": {
+            "SDR": 8.1041,
+            "SIR": 22.9987,
+            "SAR": 8.3819,
+            "ISR": 13.277
+          },
+          "accompaniment": {
+            "SDR": 15.2919,
+            "SIR": 20.1393,
+            "SAR": 17.1399,
+            "ISR": 29.5608
+          }
+        }
+      },
+      {
+        "track_name": "Invisible Familiars - Disturbing Wildlife",
+        "scores": {
+          "vocals": {
+            "SDR": 9.70997,
+            "SIR": 25.086,
+            "SAR": 9.61721,
+            "ISR": 13.4541
+          },
+          "accompaniment": {
+            "SDR": 16.8108,
+            "SIR": 21.3215,
+            "SAR": 18.4017,
+            "ISR": 24.6592
+          }
+        }
+      },
+      {
+        "track_name": "James May - All Souls Moon",
+        "scores": {
+          "vocals": {
+            "SDR": 8.37693,
+            "SIR": 21.8776,
+            "SAR": 8.69275,
+            "ISR": 13.1925
+          },
+          "accompaniment": {
+            "SDR": 12.2943,
+            "SIR": 16.7404,
+            "SAR": 13.7403,
+            "ISR": 21.0744
+          }
+        }
+      },
+      {
+        "track_name": "James May - Dont Let Go",
+        "scores": {
+          "vocals": {
+            "SDR": 7.90122,
+            "SIR": 20.671,
+            "SAR": 8.24112,
+            "ISR": 12.8178
+          },
+          "accompaniment": {
+            "SDR": 14.483,
+            "SIR": 19.329,
+            "SAR": 16.6609,
+            "ISR": 27.6775
+          }
+        }
+      },
+      {
+        "track_name": "James May - If You Say",
+        "scores": {
+          "vocals": {
+            "SDR": 10.6414,
+            "SIR": 23.9604,
+            "SAR": 10.8092,
+            "ISR": 15.8994
+          },
+          "accompaniment": {
+            "SDR": 13.725,
+            "SIR": 19.4409,
+            "SAR": 15.7471,
+            "ISR": 18.9772
+          }
+        }
+      },
+      {
+        "track_name": "James May - On The Line",
+        "scores": {
+          "vocals": {
+            "SDR": 9.1032,
+            "SIR": 23.6576,
+            "SAR": 10.07,
+            "ISR": 14.3834
+          },
+          "accompaniment": {
+            "SDR": 16.0804,
+            "SIR": 20.7322,
+            "SAR": 17.8891,
+            "ISR": 30.0874
+          }
+        }
+      },
+      {
+        "track_name": "Jay Menon - Through My Eyes",
+        "scores": {
+          "vocals": {
+            "SDR": 12.3767,
+            "SIR": 22.9892,
+            "SAR": 12.1773,
+            "ISR": 18.1952
+          },
+          "accompaniment": {
+            "SDR": 13.2837,
+            "SIR": 19.6038,
+            "SAR": 13.4421,
+            "ISR": 22.8868
+          }
+        }
+      },
+      {
+        "track_name": "Johnny Lokke - Promises & Lies",
+        "scores": {
+          "vocals": {
+            "SDR": 8.27846,
+            "SIR": 20.346,
+            "SAR": 8.89653,
+            "ISR": 13.1717
+          },
+          "accompaniment": {
+            "SDR": 14.3783,
+            "SIR": 19.3105,
+            "SAR": 16.252,
+            "ISR": 25.8162
+          }
+        }
+      },
+      {
+        "track_name": "Johnny Lokke - Whisper To A Scream",
+        "scores": {
+          "vocals": {
+            "SDR": 7.28364,
+            "SIR": 20.0502,
+            "SAR": 7.9146,
+            "ISR": 11.7854
+          },
+          "accompaniment": {
+            "SDR": 14.2398,
+            "SIR": 18.7184,
+            "SAR": 16.864,
+            "ISR": 25.6083
+          }
+        }
+      },
+      {
+        "track_name": "Jokers, Jacks & Kings - Sea Of Leaves",
+        "scores": {
+          "vocals": {
+            "SDR": 8.27638,
+            "SIR": 22.4009,
+            "SAR": 9.1738,
+            "ISR": 12.7127
+          },
+          "accompaniment": {
+            "SDR": 12.2422,
+            "SIR": 16.3424,
+            "SAR": 14.3325,
+            "ISR": 26.2659
+          }
+        }
+      },
+      {
+        "track_name": "Leaf - Come Around",
+        "scores": {
+          "vocals": {
+            "SDR": 8.54021,
+            "SIR": 18.2662,
+            "SAR": 8.42697,
+            "ISR": 13.5337
+          },
+          "accompaniment": {
+            "SDR": 16.1428,
+            "SIR": 22.4261,
+            "SAR": 19.1421,
+            "ISR": 18.2148
+          }
+        }
+      },
+      {
+        "track_name": "Leaf - Summerghost",
+        "scores": {
+          "vocals": {
+            "SDR": 7.94077,
+            "SIR": 17.6513,
+            "SAR": 8.67582,
+            "ISR": 14.5572
+          },
+          "accompaniment": {
+            "SDR": 14.6138,
+            "SIR": 21.2583,
+            "SAR": 16.4567,
+            "ISR": 26.161
+          }
+        }
+      },
+      {
+        "track_name": "Leaf - Wicked",
+        "scores": {
+          "vocals": {
+            "SDR": 9.4497,
+            "SIR": 22.8932,
+            "SAR": 9.7305,
+            "ISR": 14.4864
+          },
+          "accompaniment": {
+            "SDR": 16.0164,
+            "SIR": 21.0056,
+            "SAR": 17.5031,
+            "ISR": 27.7164
+          }
+        }
+      },
+      {
+        "track_name": "Lushlife - Toynbee Suite",
+        "scores": {
+          "vocals": {
+            "SDR": 1.47467,
+            "SIR": 4.7694,
+            "SAR": 0.73314,
+            "ISR": 9.64777
+          },
+          "accompaniment": {
+            "SDR": 17.1617,
+            "SIR": 28.8821,
+            "SAR": 18.6928,
+            "ISR": 16.3707
+          }
+        }
+      },
+      {
+        "track_name": "Matthew Entwistle - Dont You Ever",
+        "scores": {
+          "vocals": {
+            "SDR": 10.1188,
+            "SIR": 19.3448,
+            "SAR": 9.90282,
+            "ISR": 17.2928
+          },
+          "accompaniment": {
+            "SDR": 15.5695,
+            "SIR": 22.5407,
+            "SAR": 16.3144,
+            "ISR": 23.2547
+          }
+        }
+      },
+      {
+        "track_name": "Meaxic - Take A Step",
+        "scores": {
+          "vocals": {
+            "SDR": 8.86668,
+            "SIR": 20.4841,
+            "SAR": 9.41665,
+            "ISR": 15.0012
+          },
+          "accompaniment": {
+            "SDR": 15.6015,
+            "SIR": 21.3811,
+            "SAR": 17.4448,
+            "ISR": 26.2467
+          }
+        }
+      },
+      {
+        "track_name": "Meaxic - You Listen",
+        "scores": {
+          "vocals": {
+            "SDR": 9.95195,
+            "SIR": 27.8077,
+            "SAR": 9.83085,
+            "ISR": 17.0117
+          },
+          "accompaniment": {
+            "SDR": 13.0332,
+            "SIR": 19.9729,
+            "SAR": 15.4035,
+            "ISR": 19.251
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - 80s Rock",
+        "scores": {
+          "vocals": {
+            "SDR": 12.3176,
+            "SIR": 21.7842,
+            "SAR": 13.3524,
+            "ISR": 17.794
+          },
+          "accompaniment": {
+            "SDR": 15.0297,
+            "SIR": 20.4311,
+            "SAR": 16.818,
+            "ISR": 24.8989
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Beatles",
+        "scores": {
+          "vocals": {
+            "SDR": 8.90311,
+            "SIR": 19.5468,
+            "SAR": 9.37779,
+            "ISR": 14.441
+          },
+          "accompaniment": {
+            "SDR": 15.1579,
+            "SIR": 20.0639,
+            "SAR": 16.8333,
+            "ISR": 26.5716
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Britpop",
+        "scores": {
+          "vocals": {
+            "SDR": 7.85588,
+            "SIR": 16.5715,
+            "SAR": 8.41092,
+            "ISR": 12.2971
+          },
+          "accompaniment": {
+            "SDR": 11.7304,
+            "SIR": 15.3465,
+            "SAR": 14.038,
+            "ISR": 22.12
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Country1",
+        "scores": {
+          "vocals": {
+            "SDR": 11.0917,
+            "SIR": 21.319,
+            "SAR": 12.2027,
+            "ISR": 17.7826
+          },
+          "accompaniment": {
+            "SDR": 13.8592,
+            "SIR": 19.9921,
+            "SAR": 15.5003,
+            "ISR": 23.0152
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Country2",
+        "scores": {
+          "vocals": {
+            "SDR": 15.2572,
+            "SIR": 23.1534,
+            "SAR": 15.7425,
+            "ISR": 23.2008
+          },
+          "accompaniment": {
+            "SDR": 17.8599,
+            "SIR": 26.9764,
+            "SAR": 18.6755,
+            "ISR": 25.4046
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Disco",
+        "scores": {
+          "vocals": {
+            "SDR": 13.4528,
+            "SIR": 24.2075,
+            "SAR": 14.1504,
+            "ISR": 21.2015
+          },
+          "accompaniment": {
+            "SDR": 17.1899,
+            "SIR": 25.1109,
+            "SAR": 18.1604,
+            "ISR": 27.3928
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Gospel",
+        "scores": {
+          "vocals": {
+            "SDR": 16.9336,
+            "SIR": 26.0123,
+            "SAR": 17.7841,
+            "ISR": 23.8337
+          },
+          "accompaniment": {
+            "SDR": 16.28,
+            "SIR": 24.6295,
+            "SAR": 17.1943,
+            "ISR": 25.039
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Grunge",
+        "scores": {
+          "vocals": {
+            "SDR": 8.39405,
+            "SIR": 15.7789,
+            "SAR": 9.01484,
+            "ISR": 13.561
+          },
+          "accompaniment": {
+            "SDR": 13.5417,
+            "SIR": 19.3548,
+            "SAR": 15.7758,
+            "ISR": 22.522
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Hendrix",
+        "scores": {
+          "vocals": {
+            "SDR": 11.1517,
+            "SIR": 13.2959,
+            "SAR": 10.6214,
+            "ISR": 18.1688
+          },
+          "accompaniment": {
+            "SDR": 15.1538,
+            "SIR": 23.2521,
+            "SAR": 15.0103,
+            "ISR": 16.5513
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Punk",
+        "scores": {
+          "vocals": {
+            "SDR": 10.9739,
+            "SIR": 20.7058,
+            "SAR": 11.0108,
+            "ISR": 14.5884
+          },
+          "accompaniment": {
+            "SDR": 13.3328,
+            "SIR": 18.4485,
+            "SAR": 15.7827,
+            "ISR": 17.6336
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Reggae",
+        "scores": {
+          "vocals": {
+            "SDR": 16.4373,
+            "SIR": 27.694,
+            "SAR": 16.517,
+            "ISR": 23.145
+          },
+          "accompaniment": {
+            "SDR": 18.075,
+            "SIR": 27.8346,
+            "SAR": 20.9546,
+            "ISR": 20.8391
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Rock",
+        "scores": {
+          "vocals": {
+            "SDR": 10.4772,
+            "SIR": 17.8272,
+            "SAR": 10.8346,
+            "ISR": 14.7617
+          },
+          "accompaniment": {
+            "SDR": 10.6692,
+            "SIR": 15.6967,
+            "SAR": 12.8753,
+            "ISR": 19.6801
+          }
+        }
+      },
+      {
+        "track_name": "Music Delta - Rockabilly",
+        "scores": {
+          "vocals": {
+            "SDR": 9.78891,
+            "SIR": 19.1537,
+            "SAR": 11.056,
+            "ISR": 15.2638
+          },
+          "accompaniment": {
+            "SDR": 12.9873,
+            "SIR": 18.527,
+            "SAR": 14.6569,
+            "ISR": 23.2346
+          }
+        }
+      },
+      {
+        "track_name": "Night Panther - Fire",
+        "scores": {
+          "vocals": {
+            "SDR": 8.2892,
+            "SIR": 20.328,
+            "SAR": 8.92555,
+            "ISR": 13.1305
+          },
+          "accompaniment": {
+            "SDR": 10.0227,
+            "SIR": 14.5853,
+            "SAR": 11.2098,
+            "ISR": 21.113
+          }
+        }
+      },
+      {
+        "track_name": "North To Alaska - All The Same",
+        "scores": {
+          "vocals": {
+            "SDR": 7.72229,
+            "SIR": 20.5743,
+            "SAR": 8.11735,
+            "ISR": 13.1519
+          },
+          "accompaniment": {
+            "SDR": 14.9056,
+            "SIR": 17.939,
+            "SAR": 15.3045,
+            "ISR": 25.9492
+          }
+        }
+      },
+      {
+        "track_name": "Patrick Talbot - A Reason To Leave",
+        "scores": {
+          "vocals": {
+            "SDR": 10.3672,
+            "SIR": 27.3752,
+            "SAR": 11.019,
+            "ISR": 15.3817
+          },
+          "accompaniment": {
+            "SDR": 12.2429,
+            "SIR": 16.4682,
+            "SAR": 13.4563,
+            "ISR": 23.0365
+          }
+        }
+      },
+      {
+        "track_name": "Patrick Talbot - Set Me Free",
+        "scores": {
+          "vocals": {
+            "SDR": 9.68382,
+            "SIR": 24.8043,
+            "SAR": 10.2048,
+            "ISR": 15.0192
+          },
+          "accompaniment": {
+            "SDR": 9.6941,
+            "SIR": 14.3762,
+            "SAR": 11.5214,
+            "ISR": 17.4398
+          }
+        }
+      },
+      {
+        "track_name": "Phre The Eon - Everybody's Falling Apart",
+        "scores": {
+          "vocals": {
+            "SDR": 10.1257,
+            "SIR": 27.6994,
+            "SAR": 10.8028,
+            "ISR": 14.806
+          },
+          "accompaniment": {
+            "SDR": 15.1948,
+            "SIR": 21.7629,
+            "SAR": 18.5402,
+            "ISR": 19.0678
+          }
+        }
+      },
+      {
+        "track_name": "Port St Willow - Stay Even",
+        "scores": {
+          "vocals": {
+            "SDR": 3.4096,
+            "SIR": 6.48776,
+            "SAR": 3.59386,
+            "ISR": 9.77711
+          },
+          "accompaniment": {
+            "SDR": 9.87824,
+            "SIR": 18.1847,
+            "SAR": 11.5932,
+            "ISR": 15.065
+          }
+        }
+      },
+      {
+        "track_name": "Remember December - C U Next Time",
+        "scores": {
+          "vocals": {
+            "SDR": 7.39005,
+            "SIR": 14.6239,
+            "SAR": 7.88169,
+            "ISR": 11.7645
+          },
+          "accompaniment": {
+            "SDR": 11.8007,
+            "SIR": 15.7143,
+            "SAR": 14.1137,
+            "ISR": 17.7306
+          }
+        }
+      },
+      {
+        "track_name": "Secret Mountains - High Horse",
+        "scores": {
+          "vocals": {
+            "SDR": 4.10176,
+            "SIR": 15.6866,
+            "SAR": 4.12566,
+            "ISR": 9.67366
+          },
+          "accompaniment": {
+            "SDR": 14.0714,
+            "SIR": 18.9577,
+            "SAR": 16.0332,
+            "ISR": 21.5954
+          }
+        }
+      },
+      {
+        "track_name": "Skelpolu - Human Mistakes",
+        "scores": {
+          "vocals": {
+            "SDR": 5.84013,
+            "SIR": 18.6658,
+            "SAR": 6.25407,
+            "ISR": 11.3342
+          },
+          "accompaniment": {
+            "SDR": 16.1445,
+            "SIR": 21.3697,
+            "SAR": 18.5304,
+            "ISR": 30.5762
+          }
+        }
+      },
+      {
+        "track_name": "Skelpolu - Together Alone",
+        "scores": {
+          "vocals": {
+            "SDR": -0.27821,
+            "SIR": -30.7644,
+            "SAR": 4e-05,
+            "ISR": 2.15205
+          },
+          "accompaniment": {
+            "SDR": 22.6053,
+            "SIR": 42.7372,
+            "SAR": 28.4098,
+            "ISR": 20.9459
+          }
+        }
+      },
+      {
+        "track_name": "Snowmine - Curfews",
+        "scores": {
+          "vocals": {
+            "SDR": 5.52446,
+            "SIR": 17.4949,
+            "SAR": 5.90764,
+            "ISR": 8.694
+          },
+          "accompaniment": {
+            "SDR": 14.172,
+            "SIR": 17.8467,
+            "SAR": 17.6432,
+            "ISR": 19.4786
+          }
+        }
+      },
+      {
+        "track_name": "Spike Mullings - Mike's Sulking",
+        "scores": {
+          "vocals": {
+            "SDR": 7.15605,
+            "SIR": 20.5124,
+            "SAR": 7.18892,
+            "ISR": 11.9632
+          },
+          "accompaniment": {
+            "SDR": 13.0824,
+            "SIR": 16.9623,
+            "SAR": 14.7653,
+            "ISR": 26.9368
+          }
+        }
+      },
+      {
+        "track_name": "St Vitus - Word Gets Around",
+        "scores": {
+          "vocals": {
+            "SDR": 9.22813,
+            "SIR": 23.3858,
+            "SAR": 9.93457,
+            "ISR": 16.1074
+          },
+          "accompaniment": {
+            "SDR": 11.2343,
+            "SIR": 17.0765,
+            "SAR": 12.1632,
+            "ISR": 20.1095
+          }
+        }
+      },
+      {
+        "track_name": "Steven Clark - Bounty",
+        "scores": {
+          "vocals": {
+            "SDR": 5.55825,
+            "SIR": 12.8493,
+            "SAR": 5.33354,
+            "ISR": 8.94768
+          },
+          "accompaniment": {
+            "SDR": 11.2133,
+            "SIR": 13.9609,
+            "SAR": 13.7129,
+            "ISR": 19.35
+          }
+        }
+      },
+      {
+        "track_name": "Strand Of Oaks - Spacestation",
+        "scores": {
+          "vocals": {
+            "SDR": 5.86626,
+            "SIR": 19.4687,
+            "SAR": 5.7076,
+            "ISR": 11.3702
+          },
+          "accompaniment": {
+            "SDR": 11.7736,
+            "SIR": 16.5125,
+            "SAR": 14.0172,
+            "ISR": 25.9621
+          }
+        }
+      },
+      {
+        "track_name": "Sweet Lights - You Let Me Down",
+        "scores": {
+          "vocals": {
+            "SDR": 5.32897,
+            "SIR": 13.9379,
+            "SAR": 5.62667,
+            "ISR": 8.67216
+          },
+          "accompaniment": {
+            "SDR": 8.20879,
+            "SIR": 10.4055,
+            "SAR": 11.2874,
+            "ISR": 19.5597
+          }
+        }
+      },
+      {
+        "track_name": "Swinging Steaks - Lost My Way",
+        "scores": {
+          "vocals": {
+            "SDR": 4.16987,
+            "SIR": 15.0626,
+            "SAR": 4.73126,
+            "ISR": 9.19776
+          },
+          "accompaniment": {
+            "SDR": 11.9223,
+            "SIR": 16.9377,
+            "SAR": 14.8289,
+            "ISR": 20.5357
+          }
+        }
+      },
+      {
+        "track_name": "The Districts - Vermont",
+        "scores": {
+          "vocals": {
+            "SDR": 8.21099,
+            "SIR": 23.047,
+            "SAR": 8.73839,
+            "ISR": 15.3652
+          },
+          "accompaniment": {
+            "SDR": 10.4927,
+            "SIR": 16.5549,
+            "SAR": 11.3729,
+            "ISR": 24.5177
+          }
+        }
+      },
+      {
+        "track_name": "The Long Wait - Back Home To Blue",
+        "scores": {
+          "vocals": {
+            "SDR": 8.98413,
+            "SIR": 22.7143,
+            "SAR": 9.33408,
+            "ISR": 13.6103
+          },
+          "accompaniment": {
+            "SDR": 15.706,
+            "SIR": 18.8497,
+            "SAR": 16.8638,
+            "ISR": 28.5336
+          }
+        }
+      },
+      {
+        "track_name": "The Scarlet Brand - Les Fleurs Du Mal",
+        "scores": {
+          "vocals": {
+            "SDR": 7.51597,
+            "SIR": 22.6615,
+            "SAR": 7.65666,
+            "ISR": 11.4719
+          },
+          "accompaniment": {
+            "SDR": 10.4334,
+            "SIR": 14.1601,
+            "SAR": 12.6401,
+            "ISR": 25.7448
+          }
+        }
+      },
+      {
+        "track_name": "The So So Glos - Emergency",
+        "scores": {
+          "vocals": {
+            "SDR": 6.04714,
+            "SIR": 17.3009,
+            "SAR": 6.15763,
+            "ISR": 10.8781
+          },
+          "accompaniment": {
+            "SDR": 12.8646,
+            "SIR": 16.8644,
+            "SAR": 14.4989,
+            "ISR": 20.5527
+          }
+        }
+      },
+      {
+        "track_name": "The Wrong'Uns - Rothko",
+        "scores": {
+          "vocals": {
+            "SDR": 11.1606,
+            "SIR": 22.6829,
+            "SAR": 11.9686,
+            "ISR": 17.3157
+          },
+          "accompaniment": {
+            "SDR": 13.6624,
+            "SIR": 20.5838,
+            "SAR": 16.1242,
+            "ISR": 18.1028
+          }
+        }
+      },
+      {
+        "track_name": "Tim Taler - Stalker",
+        "scores": {
+          "vocals": {
+            "SDR": 5.93961,
+            "SIR": 15.663,
+            "SAR": 5.91303,
+            "ISR": 10.3718
+          },
+          "accompaniment": {
+            "SDR": 9.57475,
+            "SIR": 11.8168,
+            "SAR": 10.4881,
+            "ISR": 20.2676
+          }
+        }
+      },
+      {
+        "track_name": "Titanium - Haunted Age",
+        "scores": {
+          "vocals": {
+            "SDR": 4.52894,
+            "SIR": 19.3269,
+            "SAR": 4.45802,
+            "ISR": 6.82841
+          },
+          "accompaniment": {
+            "SDR": 11.0317,
+            "SIR": 13.008,
+            "SAR": 15.404,
+            "ISR": 24.6489
+          }
+        }
+      },
+      {
+        "track_name": "Traffic Experiment - Once More (With Feeling)",
+        "scores": {
+          "vocals": {
+            "SDR": 5.90885,
+            "SIR": 19.4217,
+            "SAR": 6.04031,
+            "ISR": 9.59568
+          },
+          "accompaniment": {
+            "SDR": 12.7515,
+            "SIR": 16.6174,
+            "SAR": 16.1713,
+            "ISR": 18.2182
+          }
+        }
+      },
+      {
+        "track_name": "Traffic Experiment - Sirens",
+        "scores": {
+          "vocals": {
+            "SDR": 5.72437,
+            "SIR": 19.0318,
+            "SAR": 5.51779,
+            "ISR": 9.32155
+          },
+          "accompaniment": {
+            "SDR": 10.2745,
+            "SIR": 13.0619,
+            "SAR": 12.7821,
+            "ISR": 17.5687
+          }
+        }
+      },
+      {
+        "track_name": "Triviul - Angelsaint",
+        "scores": {
+          "vocals": {
+            "SDR": 8.8076,
+            "SIR": 16.9894,
+            "SAR": 9.03124,
+            "ISR": 13.7485
+          },
+          "accompaniment": {
+            "SDR": 13.2972,
+            "SIR": 16.4494,
+            "SAR": 13.7676,
+            "ISR": 20.7918
+          }
+        }
+      },
+      {
+        "track_name": "Triviul - Dorothy",
+        "scores": {
+          "vocals": {
+            "SDR": 10.8417,
+            "SIR": 18.6024,
+            "SAR": 10.3282,
+            "ISR": 15.2514
+          },
+          "accompaniment": {
+            "SDR": 12.612,
+            "SIR": 17.1297,
+            "SAR": 13.0885,
+            "ISR": 19.0915
+          }
+        }
+      },
+      {
+        "track_name": "Voelund - Comfort Lives In Belief",
+        "scores": {
+          "vocals": {
+            "SDR": 4.84132,
+            "SIR": 15.5384,
+            "SAR": 5.42572,
+            "ISR": 8.42458
+          },
+          "accompaniment": {
+            "SDR": 8.83652,
+            "SIR": 11.2361,
+            "SAR": 11.5247,
+            "ISR": 21.6222
+          }
+        }
+      },
+      {
+        "track_name": "Wall Of Death - Femme",
+        "scores": {
+          "vocals": {
+            "SDR": 4.7405,
+            "SIR": 16.0957,
+            "SAR": 4.63136,
+            "ISR": 8.5076
+          },
+          "accompaniment": {
+            "SDR": 14.6727,
+            "SIR": 19.014,
+            "SAR": 18.4964,
+            "ISR": 19.3019
+          }
+        }
+      },
+      {
+        "track_name": "Young Griffo - Blood To Bone",
+        "scores": {
+          "vocals": {
+            "SDR": 7.90008,
+            "SIR": 26.142,
+            "SAR": 8.10088,
+            "ISR": 13.2098
+          },
+          "accompaniment": {
+            "SDR": 14.597,
+            "SIR": 20.6947,
+            "SAR": 17.6958,
+            "ISR": 19.127
+          }
+        }
+      },
+      {
+        "track_name": "Young Griffo - Facade",
+        "scores": {
+          "vocals": {
+            "SDR": 9.00132,
+            "SIR": 19.7921,
+            "SAR": 9.21459,
+            "ISR": 13.9706
+          },
+          "accompaniment": {
+            "SDR": 12.8753,
+            "SIR": 17.7815,
+            "SAR": 14.3314,
+            "ISR": 24.9184
+          }
+        }
+      },
+      {
+        "track_name": "Young Griffo - Pennies",
+        "scores": {
+          "vocals": {
+            "SDR": 8.47004,
+            "SIR": 21.1271,
+            "SAR": 8.45981,
+            "ISR": 13.2456
+          },
+          "accompaniment": {
+            "SDR": 14.295,
+            "SIR": 18.9764,
+            "SAR": 16.0033,
+            "ISR": 27.4233
+          }
+        }
+      },
+      {
+        "track_name": "AM Contra - Heart Peripheral",
+        "scores": {
+          "vocals": {
+            "SDR": 10.5019,
+            "SIR": 21.6456,
+            "SAR": 11.3157,
+            "ISR": 16.7876
+          },
+          "accompaniment": {
+            "SDR": 16.8578,
+            "SIR": 22.6781,
+            "SAR": 18.2187,
+            "ISR": 27.2291
+          }
+        }
+      },
+      {
+        "track_name": "Al James - Schoolboy Facination",
+        "scores": {
+          "vocals": {
+            "SDR": 7.42516,
+            "SIR": 15.6536,
+            "SAR": 7.46094,
+            "ISR": 10.9252
+          },
+          "accompaniment": {
+            "SDR": 9.44502,
+            "SIR": 11.724,
+            "SAR": 11.0882,
+            "ISR": 19.2465
+          }
+        }
+      },
+      {
+        "track_name": "Angels In Amplifiers - I'm Alright",
+        "scores": {
+          "vocals": {
+            "SDR": 9.22609,
+            "SIR": 21.4656,
+            "SAR": 9.49863,
+            "ISR": 14.8275
+          },
+          "accompaniment": {
+            "SDR": 12.9674,
+            "SIR": 18.8805,
+            "SAR": 14.1361,
+            "ISR": 25.3901
+          }
+        }
+      },
+      {
+        "track_name": "Arise - Run Run Run",
+        "scores": {
+          "vocals": {
+            "SDR": 8.76842,
+            "SIR": 23.6412,
+            "SAR": 9.12358,
+            "ISR": 13.5951
+          },
+          "accompaniment": {
+            "SDR": 15.928,
+            "SIR": 22.8837,
+            "SAR": 19.55,
+            "ISR": 18.998
+          }
+        }
+      },
+      {
+        "track_name": "BKS - Bulldozer",
+        "scores": {
+          "vocals": {
+            "SDR": 7.90826,
+            "SIR": 24.8657,
+            "SAR": 8.11272,
+            "ISR": 12.5669
+          },
+          "accompaniment": {
+            "SDR": 15.0931,
+            "SIR": 19.7735,
+            "SAR": 16.7143,
+            "ISR": 20.6661
+          }
+        }
+      },
+      {
+        "track_name": "BKS - Too Much",
+        "scores": {
+          "vocals": {
+            "SDR": 10.4192,
+            "SIR": 24.0879,
+            "SAR": 11.1524,
+            "ISR": 16.409
+          },
+          "accompaniment": {
+            "SDR": 14.6933,
+            "SIR": 20.4239,
+            "SAR": 16.0864,
+            "ISR": 27.5519
+          }
+        }
+      },
+      {
+        "track_name": "Ben Carrigan - We'll Talk About It All Tonight",
+        "scores": {
+          "vocals": {
+            "SDR": 5.10921,
+            "SIR": 16.6429,
+            "SAR": 5.01273,
+            "ISR": 8.69419
+          },
+          "accompaniment": {
+            "SDR": 12.264,
+            "SIR": 15.0653,
+            "SAR": 15.3341,
+            "ISR": 24.1785
+          }
+        }
+      },
+      {
+        "track_name": "Bobby Nobody - Stitch Up",
+        "scores": {
+          "vocals": {
+            "SDR": 8.5224,
+            "SIR": 20.6326,
+            "SAR": 8.72368,
+            "ISR": 13.7476
+          },
+          "accompaniment": {
+            "SDR": 13.4868,
+            "SIR": 18.8872,
+            "SAR": 15.3071,
+            "ISR": 22.5037
+          }
+        }
+      },
+      {
+        "track_name": "Buitraker - Revo X",
+        "scores": {
+          "vocals": {
+            "SDR": 5.00632,
+            "SIR": 10.3415,
+            "SAR": 4.87802,
+            "ISR": 8.83604
+          },
+          "accompaniment": {
+            "SDR": 14.3411,
+            "SIR": 18.0501,
+            "SAR": 16.5105,
+            "ISR": 22.6973
+          }
+        }
+      },
+      {
+        "track_name": "Carlos Gonzalez - A Place For Us",
+        "scores": {
+          "vocals": {
+            "SDR": 6.28909,
+            "SIR": 14.6588,
+            "SAR": 6.3358,
+            "ISR": 10.4418
+          },
+          "accompaniment": {
+            "SDR": 9.84974,
+            "SIR": 11.8716,
+            "SAR": 10.907,
+            "ISR": 18.7224
+          }
+        }
+      },
+      {
+        "track_name": "Cristina Vane - So Easy",
+        "scores": {
+          "vocals": {
+            "SDR": 9.65824,
+            "SIR": 19.5154,
+            "SAR": 10.4012,
+            "ISR": 13.8744
+          },
+          "accompaniment": {
+            "SDR": 14.4474,
+            "SIR": 17.7872,
+            "SAR": 15.6015,
+            "ISR": 23.9859
+          }
+        }
+      },
+      {
+        "track_name": "Detsky Sad - Walkie Talkie",
+        "scores": {
+          "vocals": {
+            "SDR": 10.3957,
+            "SIR": 21.9923,
+            "SAR": 10.9819,
+            "ISR": 16.5344
+          },
+          "accompaniment": {
+            "SDR": 12.6667,
+            "SIR": 20.0484,
+            "SAR": 14.8253,
+            "ISR": 17.2283
+          }
+        }
+      },
+      {
+        "track_name": "Enda Reilly - Cur An Long Ag Seol",
+        "scores": {
+          "vocals": {
+            "SDR": 9.21146,
+            "SIR": 18.6744,
+            "SAR": 0.65766,
+            "ISR": -4.79845
+          },
+          "accompaniment": {
+            "SDR": 13.1948,
+            "SIR": -0.59224,
+            "SAR": 2.70242,
+            "ISR": 18.082
+          }
+        }
+      },
+      {
+        "track_name": "Forkupines - Semantics",
+        "scores": {
+          "vocals": {
+            "SDR": 7.37951,
+            "SIR": 23.0314,
+            "SAR": 7.69145,
+            "ISR": 12.1834
+          },
+          "accompaniment": {
+            "SDR": 13.9493,
+            "SIR": 18.08,
+            "SAR": 16.1657,
+            "ISR": 24.1283
+          }
+        }
+      },
+      {
+        "track_name": "Georgia Wonder - Siren",
+        "scores": {
+          "vocals": {
+            "SDR": 6.31187,
+            "SIR": 15.7173,
+            "SAR": 6.52708,
+            "ISR": 10.8173
+          },
+          "accompaniment": {
+            "SDR": 10.9079,
+            "SIR": 14.7493,
+            "SAR": 13.2028,
+            "ISR": 22.2533
+          }
+        }
+      },
+      {
+        "track_name": "Girls Under Glass - We Feel Alright",
+        "scores": {
+          "vocals": {
+            "SDR": 4.86078,
+            "SIR": 12.7201,
+            "SAR": 4.92282,
+            "ISR": 8.4244
+          },
+          "accompaniment": {
+            "SDR": 12.58,
+            "SIR": 16.4122,
+            "SAR": 15.414,
+            "ISR": 23.3551
+          }
+        }
+      },
+      {
+        "track_name": "Hollow Ground - Ill Fate",
+        "scores": {
+          "vocals": {
+            "SDR": 7.00707,
+            "SIR": 15.5311,
+            "SAR": 7.75084,
+            "ISR": 12.5441
+          },
+          "accompaniment": {
+            "SDR": 15.917,
+            "SIR": 21.5775,
+            "SAR": 18.6675,
+            "ISR": 21.4818
+          }
+        }
+      },
+      {
+        "track_name": "James Elder & Mark M Thompson - The English Actor",
+        "scores": {
+          "vocals": {
+            "SDR": 6.99729,
+            "SIR": 18.0169,
+            "SAR": 7.35798,
+            "ISR": 11.4437
+          },
+          "accompaniment": {
+            "SDR": 11.5592,
+            "SIR": 14.4729,
+            "SAR": 13.85,
+            "ISR": 24.222
+          }
+        }
+      },
+      {
+        "track_name": "Juliet's Rescue - Heartbeats",
+        "scores": {
+          "vocals": {
+            "SDR": 9.38722,
+            "SIR": 24.2293,
+            "SAR": 9.82067,
+            "ISR": 14.9712
+          },
+          "accompaniment": {
+            "SDR": 16.8317,
+            "SIR": 21.8122,
+            "SAR": 18.5105,
+            "ISR": 31.3298
           }
         }
       }
@@ -33,7 +2056,7 @@
             "SAR": 10.0964,
             "ISR": 14.7435
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.4816,
             "SIR": 20.1623,
             "SAR": 17.3278,
@@ -55,7 +2078,7 @@
             "SAR": 10.3513,
             "ISR": 15.9666
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 16.2483,
             "SIR": 21.8777,
             "SAR": 17.4968,
@@ -77,7 +2100,7 @@
             "SAR": 10.2838,
             "ISR": 16.6347
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.8716,
             "SIR": 22.3494,
             "SAR": 17.176,
@@ -99,7 +2122,7 @@
             "SAR": 9.52931,
             "ISR": 13.2465
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.4412,
             "SIR": 18.7661,
             "SAR": 17.0021,
@@ -121,7 +2144,7 @@
             "SAR": 9.55387,
             "ISR": 13.5417
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.6841,
             "SIR": 19.0452,
             "SAR": 17.1219,
@@ -143,7 +2166,7 @@
             "SAR": 10.3074,
             "ISR": 14.8333
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.7343,
             "SIR": 20.1956,
             "SAR": 17.6699,
@@ -165,7 +2188,7 @@
             "SAR": 10.3701,
             "ISR": 14.653
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.5981,
             "SIR": 20.4122,
             "SAR": 17.3973,
@@ -187,7 +2210,7 @@
             "SAR": 10.3504,
             "ISR": 14.5682
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.7111,
             "SIR": 20.3581,
             "SAR": 17.6392,
@@ -209,7 +2232,7 @@
             "SAR": 9.91098,
             "ISR": 13.8572
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.0055,
             "SIR": 19.9132,
             "SAR": 16.537,
@@ -231,7 +2254,7 @@
             "SAR": 9.90405,
             "ISR": 13.8069
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.0352,
             "SIR": 19.8583,
             "SAR": 16.5648,
@@ -253,7 +2276,7 @@
             "SAR": 10.1294,
             "ISR": 14.3904
           },
-          "instrumental": {
+          "accompaniment": {
             "SDR": 15.2341,
             "SIR": 20.0053,
             "SAR": 17.2023,
@@ -261,6 +2284,1350 @@
           }
         }
       }
+    ]
+  },
+  "13_SP-UVR-4B-44100-1.pth": {
+    "model_name": "VR Arch Single Model v5: 13_SP-UVR-4B-44100-1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.61158,
+            "SIR": 24.0425,
+            "SAR": 9.95108,
+            "ISR": 14.1401
+          },
+          "accompaniment": {
+            "SDR": 15.313,
+            "SIR": 19.913,
+            "SAR": 17.181,
+            "ISR": 29.6411
+          }
+        }
+      }
+    ]
+  },
+  "14_SP-UVR-4B-44100-2.pth": {
+    "model_name": "VR Arch Single Model v5: 14_SP-UVR-4B-44100-2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.67863,
+            "SIR": 23.5652,
+            "SAR": 10.0074,
+            "ISR": 14.4707
+          },
+          "accompaniment": {
+            "SDR": 15.3879,
+            "SIR": 20.1929,
+            "SAR": 17.1843,
+            "ISR": 29.2083
+          }
+        }
+      }
+    ]
+  },
+  "15_SP-UVR-MID-44100-1.pth": {
+    "model_name": "VR Arch Single Model v5: 15_SP-UVR-MID-44100-1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.79101,
+            "SIR": 24.3351,
+            "SAR": 10.1794,
+            "ISR": 13.951
+          },
+          "accompaniment": {
+            "SDR": 15.2945,
+            "SIR": 19.4523,
+            "SAR": 17.3117,
+            "ISR": 29.1805
+          }
+        }
+      }
+    ]
+  },
+  "16_SP-UVR-MID-44100-2.pth": {
+    "model_name": "VR Arch Single Model v5: 16_SP-UVR-MID-44100-2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.70706,
+            "SIR": 24.168,
+            "SAR": 10.1456,
+            "ISR": 14.0142
+          },
+          "accompaniment": {
+            "SDR": 15.3468,
+            "SIR": 19.6379,
+            "SAR": 17.3318,
+            "ISR": 29.182
+          }
+        }
+      }
+    ]
+  },
+  "17_HP-Wind_Inst-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 17_HP-Wind_Inst-UVR",
+    "track_scores": [
+      null
+    ]
+  },
+  "UVR-De-Echo-Aggressive.pth": {
+    "model_name": "VR Arch Single Model v5: UVR-De-Echo-Aggressive by FoxJoy",
+    "track_scores": [
+      null
+    ]
+  },
+  "UVR-De-Echo-Normal.pth": {
+    "model_name": "VR Arch Single Model v5: UVR-De-Echo-Normal by FoxJoy",
+    "track_scores": [
+      null
+    ]
+  },
+  "UVR-DeEcho-DeReverb.pth": {
+    "model_name": "VR Arch Single Model v5: UVR-DeEcho-DeReverb by FoxJoy",
+    "track_scores": [
+      null
+    ]
+  },
+  "UVR-DeNoise-Lite.pth": {
+    "model_name": "VR Arch Single Model v5: UVR-DeNoise-Lite by FoxJoy",
+    "track_scores": [
+      null
+    ]
+  },
+  "UVR-DeNoise.pth": {
+    "model_name": "VR Arch Single Model v5: UVR-DeNoise by FoxJoy",
+    "track_scores": [
+      null
+    ]
+  },
+  "UVR-BVE-4B_SN-44100-1.pth": {
+    "model_name": "VR Arch Single Model v5: UVR-BVE-4B_SN-44100-1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": -0.00052,
+            "SIR": -5.31384,
+            "SAR": -0.14961,
+            "ISR": 0.25838
+          },
+          "accompaniment": {
+            "SDR": 5.96176,
+            "SIR": 5.44499,
+            "SAR": 22.8911,
+            "ISR": 17.7096
+          }
+        }
+      }
+    ]
+  },
+  "MGM_HIGHEND_v4.pth": {
+    "model_name": "VR Arch Single Model v4: MGM_HIGHEND_v4",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 8.77882,
+            "SIR": 23.3237,
+            "SAR": 9.19876,
+            "ISR": 13.2267
+          },
+          "accompaniment": {
+            "SDR": 14.5235,
+            "SIR": 18.6889,
+            "SAR": 16.3961,
+            "ISR": 30.2887
+          }
+        }
+      }
+    ]
+  },
+  "MGM_LOWEND_A_v4.pth": {
+    "model_name": "VR Arch Single Model v4: MGM_LOWEND_A_v4",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.69816,
+            "SIR": 24.318,
+            "SAR": 9.73736,
+            "ISR": 13.6806
+          },
+          "accompaniment": {
+            "SDR": 14.7954,
+            "SIR": 19.5061,
+            "SAR": 16.5979,
+            "ISR": 23.8171
+          }
+        }
+      }
+    ]
+  },
+  "MGM_LOWEND_B_v4.pth": {
+    "model_name": "VR Arch Single Model v4: MGM_LOWEND_B_v4",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.61364,
+            "SIR": 23.0202,
+            "SAR": 9.47714,
+            "ISR": 15.0702
+          },
+          "accompaniment": {
+            "SDR": 15.1628,
+            "SIR": 20.9989,
+            "SAR": 16.2524,
+            "ISR": 25.1904
+          }
+        }
+      }
+    ]
+  },
+  "MGM_MAIN_v4.pth": {
+    "model_name": "VR Arch Single Model v4: MGM_MAIN_v4",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.13893,
+            "SIR": 23.6973,
+            "SAR": 9.54069,
+            "ISR": 13.2684
+          },
+          "accompaniment": {
+            "SDR": 14.8543,
+            "SIR": 18.9902,
+            "SAR": 16.8714,
+            "ISR": 30.7065
+          }
+        }
+      }
+    ]
+  },
+  "UVR-De-Reverb-aufr33-jarredou.pth": {
+    "model_name": "VR Arch Single Model v4: UVR-De-Reverb by aufr33-jarredou",
+    "track_scores": []
+  },
+  "UVR-MDX-NET-Inst_HQ_1.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.2926,
+            "SIR": 22.6584,
+            "SAR": 11.6046,
+            "ISR": 16.0831
+          },
+          "accompaniment": {
+            "SDR": 15.7201,
+            "SIR": 27.6394,
+            "SAR": 17.9174,
+            "ISR": 18.6577
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_HQ_2.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.2891,
+            "SIR": 21.7631,
+            "SAR": 11.7597,
+            "ISR": 16.2739
+          },
+          "accompaniment": {
+            "SDR": 15.5581,
+            "SIR": 28.2464,
+            "SAR": 18.0253,
+            "ISR": 18.2691
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_HQ_3.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 3",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.3671,
+            "SIR": 21.9568,
+            "SAR": 11.7719,
+            "ISR": 16.4426
+          },
+          "accompaniment": {
+            "SDR": 15.6439,
+            "SIR": 28.5379,
+            "SAR": 18.0557,
+            "ISR": 18.3418
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_HQ_4.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 4",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.0509,
+            "SIR": 20.923,
+            "SAR": 11.5791,
+            "ISR": 16.4573
+          },
+          "accompaniment": {
+            "SDR": 15.299,
+            "SIR": 28.6137,
+            "SAR": 17.7593,
+            "ISR": 18.2594
+          }
+        }
+      }
+    ]
+  },
+  "UVR_MDXNET_Main.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Main",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.3784,
+            "SIR": 28.9564,
+            "SAR": 13.0257,
+            "ISR": 16.0096
+          },
+          "accompaniment": {
+            "SDR": 16.5944,
+            "SIR": 27.503,
+            "SAR": 19.6799,
+            "ISR": 19.2268
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_Main.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst Main",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.8043,
+            "SIR": 20.338,
+            "SAR": 11.2457,
+            "ISR": 16.1646
+          },
+          "accompaniment": {
+            "SDR": 15.1549,
+            "SIR": 27.9234,
+            "SAR": 17.4862,
+            "ISR": 18.0963
+          }
+        }
+      }
+    ]
+  },
+  "UVR_MDXNET_1_9703.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET 1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.9019,
+            "SIR": 26.6411,
+            "SAR": 12.1804,
+            "ISR": 15.7737
+          },
+          "accompaniment": {
+            "SDR": 16.0006,
+            "SIR": 26.5245,
+            "SAR": 18.7919,
+            "ISR": 18.979
+          }
+        }
+      }
+    ]
+  },
+  "UVR_MDXNET_2_9682.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET 2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.6043,
+            "SIR": 27.1946,
+            "SAR": 11.9763,
+            "ISR": 15.2049
+          },
+          "accompaniment": {
+            "SDR": 15.9336,
+            "SIR": 25.8227,
+            "SAR": 18.5257,
+            "ISR": 19.0538
+          }
+        }
+      }
+    ]
+  },
+  "UVR_MDXNET_3_9662.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET 3",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.8249,
+            "SIR": 27.3286,
+            "SAR": 12.0279,
+            "ISR": 15.6543
+          },
+          "accompaniment": {
+            "SDR": 15.9171,
+            "SIR": 26.4054,
+            "SAR": 18.4532,
+            "ISR": 19.0627
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_1.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst 1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.6262,
+            "SIR": 22.4413,
+            "SAR": 12.1032,
+            "ISR": 16.389
+          },
+          "accompaniment": {
+            "SDR": 15.6734,
+            "SIR": 28.4454,
+            "SAR": 18.5376,
+            "ISR": 18.3199
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_2.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst 2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.6504,
+            "SIR": 23.5067,
+            "SAR": 12.0741,
+            "ISR": 16.3525
+          },
+          "accompaniment": {
+            "SDR": 15.9117,
+            "SIR": 28.3142,
+            "SAR": 18.5092,
+            "ISR": 18.6941
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_3.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Inst 3",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.6203,
+            "SIR": 23.016,
+            "SAR": 12.2344,
+            "ISR": 16.2185
+          },
+          "accompaniment": {
+            "SDR": 15.7759,
+            "SIR": 28.2301,
+            "SAR": 18.5244,
+            "ISR": 18.5211
+          }
+        }
+      }
+    ]
+  },
+  "UVR_MDXNET_KARA.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Karaoke",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.8075,
+            "SIR": 27.2576,
+            "SAR": 11.2309,
+            "ISR": 13.3676
+          },
+          "accompaniment": {
+            "SDR": 15.95,
+            "SIR": 22.9958,
+            "SAR": 18.4961,
+            "ISR": 19.1189
+          }
+        }
+      }
+    ]
+  },
+  "UVR_MDXNET_KARA_2.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Karaoke 2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.0518,
+            "SIR": 20.3629,
+            "SAR": 10.2868,
+            "ISR": 14.4427
+          },
+          "accompaniment": {
+            "SDR": 15.1983,
+            "SIR": 24.6327,
+            "SAR": 17.3137,
+            "ISR": 18.3328
+          }
+        }
+      }
+    ]
+  },
+  "UVR_MDXNET_9482.onnx": {
+    "model_name": "MDX-Net Model: UVR_MDXNET_9482",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.516,
+            "SIR": 26.8431,
+            "SAR": 11.8461,
+            "ISR": 14.8779
+          },
+          "accompaniment": {
+            "SDR": 15.894,
+            "SIR": 25.3042,
+            "SAR": 18.4495,
+            "ISR": 19.0291
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Voc_FT.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Voc FT",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.2301,
+            "SIR": 29.0999,
+            "SAR": 13.182,
+            "ISR": 16.0212
+          },
+          "accompaniment": {
+            "SDR": 16.6065,
+            "SIR": 27.6932,
+            "SAR": 19.6089,
+            "ISR": 19.2326
+          }
+        }
+      }
+    ]
+  },
+  "Kim_Vocal_1.onnx": {
+    "model_name": "MDX-Net Model: Kim Vocal 1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.2721,
+            "SIR": 29.1649,
+            "SAR": 12.9673,
+            "ISR": 16.0053
+          },
+          "accompaniment": {
+            "SDR": 16.4672,
+            "SIR": 27.5393,
+            "SAR": 19.5319,
+            "ISR": 19.2202
+          }
+        }
+      }
+    ]
+  },
+  "Kim_Vocal_2.onnx": {
+    "model_name": "MDX-Net Model: Kim Vocal 2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.289,
+            "SIR": 28.7019,
+            "SAR": 13.1356,
+            "ISR": 16.2254
+          },
+          "accompaniment": {
+            "SDR": 16.5885,
+            "SIR": 28.0783,
+            "SAR": 19.7163,
+            "ISR": 19.1949
+          }
+        }
+      }
+    ]
+  },
+  "Kim_Inst.onnx": {
+    "model_name": "MDX-Net Model: Kim Inst",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.6783,
+            "SIR": 23.3283,
+            "SAR": 12.0459,
+            "ISR": 16.2864
+          },
+          "accompaniment": {
+            "SDR": 15.7901,
+            "SIR": 28.1077,
+            "SAR": 18.4411,
+            "ISR": 18.5538
+          }
+        }
+      }
+    ]
+  },
+  "Reverb_HQ_By_FoxJoy.onnx": {
+    "model_name": "MDX-Net Model: Reverb HQ By FoxJoy",
+    "track_scores": [
+      null
+    ]
+  },
+  "UVR-MDX-NET_Crowd_HQ_1.onnx": {
+    "model_name": "MDX-Net Model: UVR-MDX-NET Crowd HQ 1 By Aufr33",
+    "track_scores": [
+      null
+    ]
+  },
+  "kuielab_a_vocals.onnx": {
+    "model_name": "MDX-Net Model: kuielab_a_vocals",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.3112,
+            "SIR": 27.4733,
+            "SAR": 12.0226,
+            "ISR": 13.9254
+          },
+          "accompaniment": {
+            "SDR": 16.1396,
+            "SIR": 23.6448,
+            "SAR": 19.0724,
+            "ISR": 19.13
+          }
+        }
+      }
+    ]
+  },
+  "kuielab_a_other.onnx": {
+    "model_name": "MDX-Net Model: kuielab_a_other",
+    "track_scores": [
+      null
+    ]
+  },
+  "kuielab_a_bass.onnx": {
+    "model_name": "MDX-Net Model: kuielab_a_bass",
+    "track_scores": []
+  },
+  "kuielab_a_drums.onnx": {
+    "model_name": "MDX-Net Model: kuielab_a_drums",
+    "track_scores": []
+  },
+  "kuielab_b_vocals.onnx": {
+    "model_name": "MDX-Net Model: kuielab_b_vocals",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.6563,
+            "SIR": 26.3721,
+            "SAR": 11.7906,
+            "ISR": 15.0603
+          },
+          "accompaniment": {
+            "SDR": 15.9372,
+            "SIR": 25.6451,
+            "SAR": 18.4079,
+            "ISR": 18.9523
+          }
+        }
+      }
+    ]
+  },
+  "kuielab_b_other.onnx": {
+    "model_name": "MDX-Net Model: kuielab_b_other",
+    "track_scores": [
+      null
+    ]
+  },
+  "kuielab_b_bass.onnx": {
+    "model_name": "MDX-Net Model: kuielab_b_bass",
+    "track_scores": []
+  },
+  "kuielab_b_drums.onnx": {
+    "model_name": "MDX-Net Model: kuielab_b_drums",
+    "track_scores": []
+  },
+  "UVR-MDX-NET_Main_340.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_340",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.4494,
+            "SIR": 28.6354,
+            "SAR": 12.919,
+            "ISR": 16.6519
+          },
+          "accompaniment": {
+            "SDR": 16.4912,
+            "SIR": 28.3176,
+            "SAR": 19.112,
+            "ISR": 19.1598
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET_Main_390.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_390",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 4.8923,
+            "SIR": 28.8735,
+            "SAR": 12.9878,
+            "ISR": 6.2915
+          },
+          "accompaniment": {
+            "SDR": 9.03462,
+            "SIR": 9.19492,
+            "SAR": 15.3302,
+            "ISR": 18.6295
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET_Main_406.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_406",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.7443,
+            "SIR": 28.3612,
+            "SAR": 13.0783,
+            "ISR": 18.2171
+          },
+          "accompaniment": {
+            "SDR": 16.3575,
+            "SIR": 29.2259,
+            "SAR": 19.2459,
+            "ISR": 19.1259
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET_Main_427.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_427",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.3184,
+            "SIR": 29.0416,
+            "SAR": 13.083,
+            "ISR": 16.1862
+          },
+          "accompaniment": {
+            "SDR": 16.6029,
+            "SIR": 28.0326,
+            "SAR": 19.5602,
+            "ISR": 19.2178
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET_Main_438.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_438",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.2729,
+            "SIR": 28.6567,
+            "SAR": 13.2416,
+            "ISR": 15.9161
+          },
+          "accompaniment": {
+            "SDR": 16.4981,
+            "SIR": 27.5529,
+            "SAR": 19.5714,
+            "ISR": 19.1815
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET_Inst_82_beta.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Inst_82_beta",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.8156,
+            "SIR": 20.6419,
+            "SAR": 11.335,
+            "ISR": 15.3117
+          },
+          "accompaniment": {
+            "SDR": 14.9986,
+            "SIR": 25.9346,
+            "SAR": 17.6734,
+            "ISR": 17.6449
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET_Inst_90_beta.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Inst_90_beta",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.6498,
+            "SIR": 17.5452,
+            "SAR": 11.721,
+            "ISR": 15.5642
+          },
+          "accompaniment": {
+            "SDR": 14.3123,
+            "SIR": 26.4022,
+            "SAR": 17.7831,
+            "ISR": 16.3741
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET_Inst_187_beta.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Inst_187_beta",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.1344,
+            "SIR": 17.9928,
+            "SAR": 12.2004,
+            "ISR": 15.9915
+          },
+          "accompaniment": {
+            "SDR": 14.5594,
+            "SIR": 27.1713,
+            "SAR": 18.1641,
+            "ISR": 16.4753
+          }
+        }
+      }
+    ]
+  },
+  "UVR-MDX-NET-Inst_full_292.onnx": {
+    "model_name": "MDX-Net Model VIP: UVR-MDX-NET-Inst_full_292",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.135,
+            "SIR": 21.807,
+            "SAR": 11.5208,
+            "ISR": 16.0342
+          },
+          "accompaniment": {
+            "SDR": 15.3967,
+            "SIR": 27.4994,
+            "SAR": 17.8466,
+            "ISR": 18.241
+          }
+        }
+      }
+    ]
+  },
+  "htdemucs_ft.yaml": {
+    "model_name": "Demucs v4: htdemucs_ft",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.2685,
+            "SIR": 21.257,
+            "SAR": 11.0359,
+            "ISR": 19.3753
+          },
+          "drums": {
+            "SDR": 13.235,
+            "SIR": 23.3053,
+            "SAR": 13.0313,
+            "ISR": 17.2889
+          },
+          "bass": {
+            "SDR": 9.72743,
+            "SIR": 19.5435,
+            "SAR": 9.20801,
+            "ISR": 13.5037
+          },
+          "other": {
+            "SDR": 7.25411,
+            "SIR": 10.8728,
+            "SAR": 7.31316,
+            "ISR": 14.1944
+          }
+        }
+      }
+    ]
+  },
+  "htdemucs.yaml": {
+    "model_name": "Demucs v4: htdemucs",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.0095,
+            "SIR": 20.2894,
+            "SAR": 10.7492,
+            "ISR": 19.1796
+          },
+          "drums": {
+            "SDR": 13.011,
+            "SIR": 22.7843,
+            "SAR": 12.9744,
+            "ISR": 17.4674
+          },
+          "bass": {
+            "SDR": 9.17211,
+            "SIR": 18.7906,
+            "SAR": 8.75809,
+            "ISR": 13.0067
+          },
+          "other": {
+            "SDR": 7.16063,
+            "SIR": 10.8834,
+            "SAR": 6.9937,
+            "ISR": 14.244
+          }
+        }
+      }
+    ]
+  },
+  "hdemucs_mmi.yaml": {
+    "model_name": "Demucs v4: hdemucs_mmi",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 11.1687,
+            "SIR": 20.9333,
+            "SAR": 11.0289,
+            "ISR": 19.1138
+          },
+          "drums": {
+            "SDR": 12.4217,
+            "SIR": 23.2568,
+            "SAR": 12.3392,
+            "ISR": 16.7341
+          },
+          "bass": {
+            "SDR": 9.1504,
+            "SIR": 18.4985,
+            "SAR": 8.87331,
+            "ISR": 13.3686
+          },
+          "other": {
+            "SDR": 7.17736,
+            "SIR": 10.6928,
+            "SAR": 7.28959,
+            "ISR": 14.5021
+          }
+        }
+      }
+    ]
+  },
+  "htdemucs_6s.yaml": {
+    "model_name": "Demucs v4: htdemucs_6s",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.8446,
+            "SIR": 19.4989,
+            "SAR": 10.6463,
+            "ISR": 19.1945
+          },
+          "drums": {
+            "SDR": 12.8115,
+            "SIR": 22.638,
+            "SAR": 12.997,
+            "ISR": 16.9512
+          },
+          "bass": {
+            "SDR": 9.15013,
+            "SIR": 16.2437,
+            "SAR": 8.85638,
+            "ISR": 13.1591
+          },
+          "other": {
+            "SDR": 0.00053,
+            "SIR": 11.782,
+            "SAR": 0.00118,
+            "ISR": 0.2268
+          }
+        }
+      }
+    ]
+  },
+  "MDX23C-8KFFT-InstVoc_HQ.ckpt": {
+    "model_name": "MDX23C Model: MDX23C-InstVoc HQ",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.7312,
+            "SIR": 29.3476,
+            "SAR": 13.4577,
+            "ISR": 16.095
+          },
+          "accompaniment": {
+            "SDR": 16.8081,
+            "SIR": 27.6401,
+            "SAR": 19.9845,
+            "ISR": 19.3202
+          }
+        }
+      }
+    ]
+  },
+  "MDX23C_D1581.ckpt": {
+    "model_name": "MDX23C Model VIP: MDX23C_D1581",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.0391,
+            "SIR": 27.4449,
+            "SAR": 12.1722,
+            "ISR": 14.8268
+          },
+          "accompaniment": {
+            "SDR": 16.3295,
+            "SIR": 24.8897,
+            "SAR": 18.9426,
+            "ISR": 19.1322
+          }
+        }
+      }
+    ]
+  },
+  "MDX23C-8KFFT-InstVoc_HQ_2.ckpt": {
+    "model_name": "MDX23C Model VIP: MDX23C-InstVoc HQ 2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.7508,
+            "SIR": 29.9531,
+            "SAR": 13.3726,
+            "ISR": 16.0716
+          },
+          "accompaniment": {
+            "SDR": 16.9593,
+            "SIR": 27.5912,
+            "SAR": 19.9074,
+            "ISR": 19.5809
+          }
+        }
+      }
+    ]
+  },
+  "model_bs_roformer_ep_317_sdr_12.9755.ckpt": {
+    "model_name": "Roformer Model: BS-Roformer-Viperx-1297",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 13.5735,
+            "SIR": 30.32,
+            "SAR": 14.0441,
+            "ISR": 17.2849
+          },
+          "accompaniment": {
+            "SDR": 17.2905,
+            "SIR": 30.0163,
+            "SAR": 20.6951,
+            "ISR": 19.3823
+          }
+        }
+      }
+    ]
+  },
+  "model_bs_roformer_ep_368_sdr_12.9628.ckpt": {
+    "model_name": "Roformer Model: BS-Roformer-Viperx-1296",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 13.5542,
+            "SIR": 30.4519,
+            "SAR": 14.0864,
+            "ISR": 17.2478
+          },
+          "accompaniment": {
+            "SDR": 17.3035,
+            "SIR": 30.0666,
+            "SAR": 20.6723,
+            "ISR": 19.3953
+          }
+        }
+      }
+    ]
+  },
+  "model_bs_roformer_ep_937_sdr_10.5309.ckpt": {
+    "model_name": "Roformer Model: BS-Roformer-Viperx-1053",
+    "track_scores": [
+      null
+    ]
+  },
+  "model_mel_band_roformer_ep_3005_sdr_11.4360.ckpt": {
+    "model_name": "Roformer Model: Mel-Roformer-Viperx-1143",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.3425,
+            "SIR": 29.3362,
+            "SAR": 13.0711,
+            "ISR": 16.2842
+          },
+          "accompaniment": {
+            "SDR": 16.4826,
+            "SIR": 27.7054,
+            "SAR": 19.3585,
+            "ISR": 19.247
+          }
+        }
+      }
+    ]
+  },
+  "MDX23C-De-Reverb-aufr33-jarredou.ckpt": {
+    "model_name": "MDX23C Model: MDX23C De-Reverb by aufr33-jarredou",
+    "track_scores": []
+  },
+  "mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt": {
+    "model_name": "Roformer Model: Mel-Roformer-Karaoke-Aufr33-Viperx",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.883,
+            "SIR": 30.7823,
+            "SAR": 13.354,
+            "ISR": 14.825
+          },
+          "accompaniment": {
+            "SDR": 17.1356,
+            "SIR": 24.909,
+            "SAR": 20.1133,
+            "ISR": 19.4389
+          }
+        }
+      }
+    ]
+  },
+  "denoise_mel_band_roformer_aufr33_sdr_27.9959.ckpt": {
+    "model_name": "Roformer Model: Mel-Roformer-Denoise-Aufr33",
+    "track_scores": []
+  },
+  "denoise_mel_band_roformer_aufr33_aggr_sdr_27.9768.ckpt": {
+    "model_name": "Roformer Model: Mel-Roformer-Denoise-Aufr33-Aggr",
+    "track_scores": []
+  },
+  "mel_band_roformer_crowd_aufr33_viperx_sdr_8.7144.ckpt": {
+    "model_name": "Roformer Model: Mel-Roformer-Crowd-Aufr33-Viperx",
+    "track_scores": []
+  },
+  "deverb_bs_roformer_8_384dim_10depth.ckpt": {
+    "model_name": "Roformer Model: BS-Roformer-De-Reverb",
+    "track_scores": [
+      null
+    ]
+  },
+  "vocals_mel_band_roformer.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer | Vocals by Kimberley Jensen",
+    "track_scores": []
+  },
+  "mel_band_roformer_kim_ft_unwa.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | FT by unwa",
+    "track_scores": []
+  },
+  "melband_roformer_inst_v1e.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | Inst V1 (E) by Unwa",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 12.0889,
+            "SIR": 30.0273,
+            "SAR": 12.7786,
+            "ISR": 14.9145
+          },
+          "accompaniment": {
+            "SDR": 16.631,
+            "SIR": 25.3515,
+            "SAR": 19.4912,
+            "ISR": 19.3698
+          }
+        }
+      }
+    ]
+  },
+  "dereverb_mel_band_roformer_anvuew_sdr_19.1729.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer | De-Reverb by anvuew",
+    "track_scores": [
+      null
+    ]
+  },
+  "dereverb_mel_band_roformer_less_aggressive_anvuew_sdr_18.8050.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer | De-Reverb Less Aggressive by anvuew",
+    "track_scores": [
+      null
+    ]
+  },
+  "dereverb-echo_mel_band_roformer_sdr_10.0169.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer | De-Reverb-Echo by Sucial",
+    "track_scores": [
+      null
+    ]
+  },
+  "dereverb-echo_mel_band_roformer_sdr_13.4843_v2.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer | De-Reverb-Echo V2 by Sucial",
+    "track_scores": [
+      null
+    ]
+  },
+  "MelBandRoformerSYHFT.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | SYHFT by SYH99999",
+    "track_scores": []
+  },
+  "MelBandRoformerSYHFTV2.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | SYHFT V2 by SYH99999",
+    "track_scores": []
+  },
+  "MelBandRoformerSYHFTV2.5.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | SYHFT V2.5 by SYH99999",
+    "track_scores": []
+  },
+  "MelBandRoformerSYHFTV3Epsilon.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | SYHFT V3 by SYH99999",
+    "track_scores": []
+  },
+  "MelBandRoformerBigSYHFTV1.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | Big SYHFT V1 by SYH99999",
+    "track_scores": []
+  },
+  "melband_roformer_big_beta4.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | Big Beta 4 FT by unwa",
+    "track_scores": []
+  },
+  "melband_roformer_big_beta5e.ckpt": {
+    "model_name": "Roformer Model: MelBand Roformer Kim | Big Beta 5e FT by unwa",
+    "track_scores": []
+  },
+  "model_chorus_bs_roformer_ep_267_sdr_24.1275.ckpt": {
+    "model_name": "Roformer Model: BS Roformer | Chorus Male-Female by Sucial",
+    "track_scores": [
+      null
     ]
   }
 }

--- a/audio_separator/models-scores.json
+++ b/audio_separator/models-scores.json
@@ -3006,44 +3006,87 @@
             "ISR": 29.182
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.05476,
+            "SIR": 14.7077,
+            "SAR": 3.82144,
+            "ISR": 7.84507
+          },
+          "instrumental": {
+            "SDR": 15.1911,
+            "SIR": 19.3774,
+            "SAR": 19.53,
+            "ISR": 18.7747
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.88091,
+        "SIR": 19.4379,
+        "SAR": 6.98352,
+        "ISR": 10.9296
+      },
+      "instrumental": {
+        "SDR": 15.269,
+        "SIR": 19.5076,
+        "SAR": 18.4309,
+        "ISR": 23.9783
+      }
+    }
   },
   "17_HP-Wind_Inst-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 17_HP-Wind_Inst-UVR",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "UVR-De-Echo-Aggressive.pth": {
     "model_name": "VR Arch Single Model v5: UVR-De-Echo-Aggressive by FoxJoy",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "UVR-De-Echo-Normal.pth": {
     "model_name": "VR Arch Single Model v5: UVR-De-Echo-Normal by FoxJoy",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "UVR-DeEcho-DeReverb.pth": {
     "model_name": "VR Arch Single Model v5: UVR-DeEcho-DeReverb by FoxJoy",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "UVR-DeNoise-Lite.pth": {
     "model_name": "VR Arch Single Model v5: UVR-DeNoise-Lite by FoxJoy",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "UVR-DeNoise.pth": {
     "model_name": "VR Arch Single Model v5: UVR-DeNoise by FoxJoy",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "UVR-BVE-4B_SN-44100-1.pth": {
     "model_name": "VR Arch Single Model v5: UVR-BVE-4B_SN-44100-1",
@@ -3064,8 +3107,39 @@
             "ISR": 17.7096
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 0.0143,
+            "SIR": 5.71885,
+            "SAR": 0.00389,
+            "ISR": 2.65473
+          },
+          "instrumental": {
+            "SDR": 12.0434,
+            "SIR": 13.2314,
+            "SAR": 20.3884,
+            "ISR": 18.1082
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 0.00689,
+        "SIR": 0.202505,
+        "SAR": -0.07286,
+        "ISR": 1.45655
+      },
+      "instrumental": {
+        "SDR": 9.00258,
+        "SIR": 9.3382,
+        "SAR": 21.6397,
+        "ISR": 17.9089
+      }
+    }
   },
   "MGM_HIGHEND_v4.pth": {
     "model_name": "VR Arch Single Model v4: MGM_HIGHEND_v4",
@@ -3086,8 +3160,39 @@
             "ISR": 30.2887
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 3.90158,
+            "SIR": 15.9598,
+            "SAR": 3.37143,
+            "ISR": 6.56793
+          },
+          "instrumental": {
+            "SDR": 14.4628,
+            "SIR": 17.3509,
+            "SAR": 18.4845,
+            "ISR": 18.8014
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.3402,
+        "SIR": 19.6417,
+        "SAR": 6.2851,
+        "ISR": 9.89731
+      },
+      "instrumental": {
+        "SDR": 14.4931,
+        "SIR": 18.0199,
+        "SAR": 17.4403,
+        "ISR": 24.545
+      }
+    }
   },
   "MGM_LOWEND_A_v4.pth": {
     "model_name": "VR Arch Single Model v4: MGM_LOWEND_A_v4",
@@ -3108,8 +3213,39 @@
             "ISR": 23.8171
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.13243,
+            "SIR": 17.8811,
+            "SAR": 3.52338,
+            "ISR": 6.90286
+          },
+          "instrumental": {
+            "SDR": 14.9123,
+            "SIR": 18.3341,
+            "SAR": 19.4275,
+            "ISR": 18.9589
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.9153,
+        "SIR": 21.0996,
+        "SAR": 6.63037,
+        "ISR": 10.2917
+      },
+      "instrumental": {
+        "SDR": 14.8539,
+        "SIR": 18.9201,
+        "SAR": 18.0127,
+        "ISR": 21.388
+      }
+    }
   },
   "MGM_LOWEND_B_v4.pth": {
     "model_name": "VR Arch Single Model v4: MGM_LOWEND_B_v4",
@@ -3130,8 +3266,39 @@
             "ISR": 25.1904
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 3.9675,
+            "SIR": 15.4909,
+            "SAR": 2.98769,
+            "ISR": 8.2918
+          },
+          "instrumental": {
+            "SDR": 14.8575,
+            "SIR": 19.7225,
+            "SAR": 17.7783,
+            "ISR": 18.5521
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.79057,
+        "SIR": 19.2555,
+        "SAR": 6.23242,
+        "ISR": 11.681
+      },
+      "instrumental": {
+        "SDR": 15.0101,
+        "SIR": 20.3607,
+        "SAR": 17.0154,
+        "ISR": 21.8712
+      }
+    }
   },
   "MGM_MAIN_v4.pth": {
     "model_name": "VR Arch Single Model v4: MGM_MAIN_v4",
@@ -3152,12 +3319,45 @@
             "ISR": 30.7065
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 3.72751,
+            "SIR": 19.3325,
+            "SAR": 3.02685,
+            "ISR": 5.7645
+          },
+          "instrumental": {
+            "SDR": 14.4502,
+            "SIR": 16.2785,
+            "SAR": 19.0347,
+            "ISR": 19.0905
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.43322,
+        "SIR": 21.5149,
+        "SAR": 6.28377,
+        "ISR": 9.51645
+      },
+      "instrumental": {
+        "SDR": 14.6523,
+        "SIR": 17.6344,
+        "SAR": 17.9531,
+        "ISR": 24.8985
+      }
+    }
   },
   "UVR-De-Reverb-aufr33-jarredou.pth": {
     "model_name": "VR Arch Single Model v4: UVR-De-Reverb by aufr33-jarredou",
-    "track_scores": []
+    "track_scores": [
+      null
+    ]
   },
   "UVR-MDX-NET-Inst_HQ_1.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 1",
@@ -3178,8 +3378,39 @@
             "ISR": 18.6577
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.26685,
+            "SIR": 19.0489,
+            "SAR": 5.43294,
+            "ISR": 9.16527
+          },
+          "instrumental": {
+            "SDR": 16.5292,
+            "SIR": 23.6979,
+            "SAR": 19.953,
+            "ISR": 18.9037
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.27972,
+        "SIR": 20.8537,
+        "SAR": 8.51877,
+        "ISR": 12.6242
+      },
+      "instrumental": {
+        "SDR": 16.1246,
+        "SIR": 25.6686,
+        "SAR": 18.9352,
+        "ISR": 18.7807
+      }
+    }
   },
   "UVR-MDX-NET-Inst_HQ_2.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 2",
@@ -3200,8 +3431,39 @@
             "ISR": 18.2691
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.75013,
+            "SIR": 18.1092,
+            "SAR": 5.6745,
+            "ISR": 10.305
+          },
+          "instrumental": {
+            "SDR": 16.5295,
+            "SIR": 25.0494,
+            "SAR": 19.9577,
+            "ISR": 18.7263
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.51961,
+        "SIR": 19.9362,
+        "SAR": 8.7171,
+        "ISR": 13.2895
+      },
+      "instrumental": {
+        "SDR": 16.0438,
+        "SIR": 26.6479,
+        "SAR": 18.9915,
+        "ISR": 18.4977
+      }
+    }
   },
   "UVR-MDX-NET-Inst_HQ_3.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 3",
@@ -3222,8 +3484,39 @@
             "ISR": 18.3418
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.62282,
+            "SIR": 18.7143,
+            "SAR": 5.72698,
+            "ISR": 9.80979
+          },
+          "instrumental": {
+            "SDR": 16.512,
+            "SIR": 24.6836,
+            "SAR": 19.931,
+            "ISR": 18.8168
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.49496,
+        "SIR": 20.3356,
+        "SAR": 8.74944,
+        "ISR": 13.1262
+      },
+      "instrumental": {
+        "SDR": 16.078,
+        "SIR": 26.6107,
+        "SAR": 18.9933,
+        "ISR": 18.5793
+      }
+    }
   },
   "UVR-MDX-NET-Inst_HQ_4.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst HQ 4",
@@ -3244,8 +3537,39 @@
             "ISR": 18.2594
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.85686,
+            "SIR": 19.2837,
+            "SAR": 5.7082,
+            "ISR": 10.1135
+          },
+          "instrumental": {
+            "SDR": 16.7591,
+            "SIR": 25.0221,
+            "SAR": 20.0476,
+            "ISR": 19.0067
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.45388,
+        "SIR": 20.1033,
+        "SAR": 8.64365,
+        "ISR": 13.2854
+      },
+      "instrumental": {
+        "SDR": 16.029,
+        "SIR": 26.8179,
+        "SAR": 18.9034,
+        "ISR": 18.633
+      }
+    }
   },
   "UVR_MDXNET_Main.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Main",
@@ -3266,8 +3590,39 @@
             "ISR": 19.2268
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.63812,
+            "SIR": 17.4406,
+            "SAR": 5.78804,
+            "ISR": 10.1273
+          },
+          "instrumental": {
+            "SDR": 16.5084,
+            "SIR": 24.7649,
+            "SAR": 19.8021,
+            "ISR": 18.7235
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 9.00826,
+        "SIR": 23.1985,
+        "SAR": 9.40687,
+        "ISR": 13.0684
+      },
+      "instrumental": {
+        "SDR": 16.5514,
+        "SIR": 26.1339,
+        "SAR": 19.741,
+        "ISR": 18.9751
+      }
+    }
   },
   "UVR-MDX-NET-Inst_Main.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst Main",
@@ -3288,8 +3643,39 @@
             "ISR": 18.0963
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.94817,
+            "SIR": 18.4295,
+            "SAR": 5.567,
+            "ISR": 9.73235
+          },
+          "instrumental": {
+            "SDR": 16.4933,
+            "SIR": 24.3046,
+            "SAR": 19.8225,
+            "ISR": 18.7949
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.37623,
+        "SIR": 19.3837,
+        "SAR": 8.40635,
+        "ISR": 12.9485
+      },
+      "instrumental": {
+        "SDR": 15.8241,
+        "SIR": 26.114,
+        "SAR": 18.6544,
+        "ISR": 18.4456
+      }
+    }
   },
   "UVR_MDXNET_1_9703.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET 1",
@@ -3310,8 +3696,39 @@
             "ISR": 18.979
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.5934,
+            "SIR": 17.0409,
+            "SAR": 5.26672,
+            "ISR": 10.3872
+          },
+          "instrumental": {
+            "SDR": 16.4668,
+            "SIR": 24.9046,
+            "SAR": 19.569,
+            "ISR": 18.5774
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.74765,
+        "SIR": 21.841,
+        "SAR": 8.72356,
+        "ISR": 13.0804
+      },
+      "instrumental": {
+        "SDR": 16.2337,
+        "SIR": 25.7145,
+        "SAR": 19.1805,
+        "ISR": 18.7782
+      }
+    }
   },
   "UVR_MDXNET_2_9682.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET 2",
@@ -3332,8 +3749,39 @@
             "ISR": 19.0538
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.46453,
+            "SIR": 17.675,
+            "SAR": 4.99802,
+            "ISR": 9.81412
+          },
+          "instrumental": {
+            "SDR": 16.3486,
+            "SIR": 24.0614,
+            "SAR": 19.3918,
+            "ISR": 18.7301
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.53441,
+        "SIR": 22.4348,
+        "SAR": 8.48716,
+        "ISR": 12.5095
+      },
+      "instrumental": {
+        "SDR": 16.1411,
+        "SIR": 24.9421,
+        "SAR": 18.9588,
+        "ISR": 18.892
+      }
+    }
   },
   "UVR_MDXNET_3_9662.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET 3",
@@ -3354,8 +3802,39 @@
             "ISR": 19.0627
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.42437,
+            "SIR": 18.0352,
+            "SAR": 4.82973,
+            "ISR": 9.64703
+          },
+          "instrumental": {
+            "SDR": 16.4386,
+            "SIR": 24.5125,
+            "SAR": 19.4329,
+            "ISR": 18.7654
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.62463,
+        "SIR": 22.6819,
+        "SAR": 8.42882,
+        "ISR": 12.6507
+      },
+      "instrumental": {
+        "SDR": 16.1778,
+        "SIR": 25.459,
+        "SAR": 18.943,
+        "ISR": 18.914
+      }
+    }
   },
   "UVR-MDX-NET-Inst_1.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst 1",
@@ -3376,8 +3855,39 @@
             "ISR": 18.3199
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.82133,
+            "SIR": 18.827,
+            "SAR": 5.68742,
+            "ISR": 9.93487
+          },
+          "instrumental": {
+            "SDR": 16.4818,
+            "SIR": 24.78,
+            "SAR": 19.7198,
+            "ISR": 18.7803
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.72377,
+        "SIR": 20.6341,
+        "SAR": 8.89531,
+        "ISR": 13.1619
+      },
+      "instrumental": {
+        "SDR": 16.0776,
+        "SIR": 26.6127,
+        "SAR": 19.1287,
+        "ISR": 18.5501
+      }
+    }
   },
   "UVR-MDX-NET-Inst_2.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst 2",
@@ -3398,8 +3908,39 @@
             "ISR": 18.6941
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.81251,
+            "SIR": 18.688,
+            "SAR": 5.91282,
+            "ISR": 10.5675
+          },
+          "instrumental": {
+            "SDR": 16.6667,
+            "SIR": 25.3572,
+            "SAR": 19.8788,
+            "ISR": 18.9157
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.73146,
+        "SIR": 21.0973,
+        "SAR": 8.99346,
+        "ISR": 13.46
+      },
+      "instrumental": {
+        "SDR": 16.2892,
+        "SIR": 26.8357,
+        "SAR": 19.194,
+        "ISR": 18.8049
+      }
+    }
   },
   "UVR-MDX-NET-Inst_3.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Inst 3",
@@ -3420,8 +3961,39 @@
             "ISR": 18.5211
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.77412,
+            "SIR": 16.6923,
+            "SAR": 5.69646,
+            "ISR": 9.88816
+          },
+          "instrumental": {
+            "SDR": 16.5002,
+            "SIR": 24.725,
+            "SAR": 19.8214,
+            "ISR": 18.6737
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.69721,
+        "SIR": 19.8541,
+        "SAR": 8.96543,
+        "ISR": 13.0533
+      },
+      "instrumental": {
+        "SDR": 16.138,
+        "SIR": 26.4776,
+        "SAR": 19.1729,
+        "ISR": 18.5974
+      }
+    }
   },
   "UVR_MDXNET_KARA.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Karaoke",
@@ -3442,8 +4014,39 @@
             "ISR": 19.1189
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 2.5289,
+            "SIR": 11.2152,
+            "SAR": 2.35093,
+            "ISR": 5.35324
+          },
+          "instrumental": {
+            "SDR": 15.417,
+            "SIR": 19.1696,
+            "SAR": 18.0835,
+            "ISR": 18.3171
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.6682,
+        "SIR": 19.2364,
+        "SAR": 6.79092,
+        "ISR": 9.36042
+      },
+      "instrumental": {
+        "SDR": 15.6835,
+        "SIR": 21.0827,
+        "SAR": 18.2898,
+        "ISR": 18.718
+      }
+    }
   },
   "UVR_MDXNET_KARA_2.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Karaoke 2",
@@ -3464,8 +4067,39 @@
             "ISR": 18.3328
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.00209,
+            "SIR": 14.6178,
+            "SAR": 4.02018,
+            "ISR": 6.89909
+          },
+          "instrumental": {
+            "SDR": 16.0738,
+            "SIR": 21.7738,
+            "SAR": 19.382,
+            "ISR": 18.5912
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.02694,
+        "SIR": 17.4903,
+        "SAR": 7.15349,
+        "ISR": 10.6709
+      },
+      "instrumental": {
+        "SDR": 15.636,
+        "SIR": 23.2033,
+        "SAR": 18.3479,
+        "ISR": 18.462
+      }
+    }
   },
   "UVR_MDXNET_9482.onnx": {
     "model_name": "MDX-Net Model: UVR_MDXNET_9482",
@@ -3486,8 +4120,39 @@
             "ISR": 19.0291
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.70393,
+            "SIR": 15.5526,
+            "SAR": 4.81548,
+            "ISR": 9.38948
+          },
+          "instrumental": {
+            "SDR": 16.1586,
+            "SIR": 23.716,
+            "SAR": 19.3851,
+            "ISR": 18.5291
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.10996,
+        "SIR": 21.1978,
+        "SAR": 8.33079,
+        "ISR": 12.1337
+      },
+      "instrumental": {
+        "SDR": 16.0263,
+        "SIR": 24.5101,
+        "SAR": 18.9173,
+        "ISR": 18.7791
+      }
+    }
   },
   "UVR-MDX-NET-Voc_FT.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Voc FT",
@@ -3508,8 +4173,39 @@
             "ISR": 19.2326
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.85247,
+            "SIR": 18.6162,
+            "SAR": 5.85353,
+            "ISR": 9.82122
+          },
+          "instrumental": {
+            "SDR": 16.5346,
+            "SIR": 24.6446,
+            "SAR": 19.9257,
+            "ISR": 18.9024
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 9.04129,
+        "SIR": 23.858,
+        "SAR": 9.51777,
+        "ISR": 12.9212
+      },
+      "instrumental": {
+        "SDR": 16.5706,
+        "SIR": 26.1689,
+        "SAR": 19.7673,
+        "ISR": 19.0675
+      }
+    }
   },
   "Kim_Vocal_1.onnx": {
     "model_name": "MDX-Net Model: Kim Vocal 1",
@@ -3530,8 +4226,39 @@
             "ISR": 19.2202
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.7787,
+            "SIR": 19.3037,
+            "SAR": 5.83443,
+            "ISR": 9.62516
+          },
+          "instrumental": {
+            "SDR": 16.6193,
+            "SIR": 24.5137,
+            "SAR": 19.9734,
+            "ISR": 18.9958
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 9.0254,
+        "SIR": 24.2343,
+        "SAR": 9.40086,
+        "ISR": 12.8152
+      },
+      "instrumental": {
+        "SDR": 16.5433,
+        "SIR": 26.0265,
+        "SAR": 19.7527,
+        "ISR": 19.108
+      }
+    }
   },
   "Kim_Vocal_2.onnx": {
     "model_name": "MDX-Net Model: Kim Vocal 2",
@@ -3552,8 +4279,39 @@
             "ISR": 19.1949
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.78748,
+            "SIR": 18.1983,
+            "SAR": 5.91704,
+            "ISR": 10.1435
+          },
+          "instrumental": {
+            "SDR": 16.5766,
+            "SIR": 24.9934,
+            "SAR": 19.8726,
+            "ISR": 18.7919
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 9.03824,
+        "SIR": 23.4501,
+        "SAR": 9.52632,
+        "ISR": 13.1845
+      },
+      "instrumental": {
+        "SDR": 16.5825,
+        "SIR": 26.5358,
+        "SAR": 19.7944,
+        "ISR": 18.9934
+      }
+    }
   },
   "Kim_Inst.onnx": {
     "model_name": "MDX-Net Model: Kim Inst",
@@ -3574,20 +4332,55 @@
             "ISR": 18.5538
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.26277,
+            "SIR": 19.5259,
+            "SAR": 4.96245,
+            "ISR": 8.62868
+          },
+          "instrumental": {
+            "SDR": 16.55,
+            "SIR": 23.7871,
+            "SAR": 19.7671,
+            "ISR": 18.9284
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.47053,
+        "SIR": 21.4271,
+        "SAR": 8.50418,
+        "ISR": 12.4575
+      },
+      "instrumental": {
+        "SDR": 16.17,
+        "SIR": 25.9474,
+        "SAR": 19.1041,
+        "ISR": 18.7411
+      }
+    }
   },
   "Reverb_HQ_By_FoxJoy.onnx": {
     "model_name": "MDX-Net Model: Reverb HQ By FoxJoy",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "UVR-MDX-NET_Crowd_HQ_1.onnx": {
     "model_name": "MDX-Net Model: UVR-MDX-NET Crowd HQ 1 By Aufr33",
     "track_scores": [
+      null,
       null
-    ]
+    ],
+    "median_scores": null
   },
   "kuielab_a_vocals.onnx": {
     "model_name": "MDX-Net Model: kuielab_a_vocals",
@@ -3608,22 +4401,58 @@
             "ISR": 19.13
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 6.03051,
+            "SIR": 19.0287,
+            "SAR": 6.30829,
+            "ISR": 10.7322
+          },
+          "instrumental": {
+            "SDR": 16.4026,
+            "SIR": 25.2452,
+            "SAR": 20.0441,
+            "ISR": 18.8
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.67085,
+        "SIR": 23.251,
+        "SAR": 9.16545,
+        "ISR": 12.3288
+      },
+      "instrumental": {
+        "SDR": 16.2711,
+        "SIR": 24.445,
+        "SAR": 19.5583,
+        "ISR": 18.965
+      }
+    }
   },
   "kuielab_a_other.onnx": {
     "model_name": "MDX-Net Model: kuielab_a_other",
     "track_scores": [
+      null,
       null
     ]
   },
   "kuielab_a_bass.onnx": {
     "model_name": "MDX-Net Model: kuielab_a_bass",
-    "track_scores": []
+    "track_scores": [
+      null
+    ]
   },
   "kuielab_a_drums.onnx": {
     "model_name": "MDX-Net Model: kuielab_a_drums",
-    "track_scores": []
+    "track_scores": [
+      null
+    ]
   },
   "kuielab_b_vocals.onnx": {
     "model_name": "MDX-Net Model: kuielab_b_vocals",
@@ -3644,22 +4473,58 @@
             "ISR": 18.9523
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.30456,
+            "SIR": 21.1354,
+            "SAR": 4.92979,
+            "ISR": 8.8335
+          },
+          "instrumental": {
+            "SDR": 16.2972,
+            "SIR": 23.2941,
+            "SAR": 19.5481,
+            "ISR": 19.0885
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.48043,
+        "SIR": 23.7538,
+        "SAR": 8.36019,
+        "ISR": 11.9469
+      },
+      "instrumental": {
+        "SDR": 16.1172,
+        "SIR": 24.4696,
+        "SAR": 18.978,
+        "ISR": 19.0204
+      }
+    }
   },
   "kuielab_b_other.onnx": {
     "model_name": "MDX-Net Model: kuielab_b_other",
     "track_scores": [
+      null,
       null
     ]
   },
   "kuielab_b_bass.onnx": {
     "model_name": "MDX-Net Model: kuielab_b_bass",
-    "track_scores": []
+    "track_scores": [
+      null
+    ]
   },
   "kuielab_b_drums.onnx": {
     "model_name": "MDX-Net Model: kuielab_b_drums",
-    "track_scores": []
+    "track_scores": [
+      null
+    ]
   },
   "UVR-MDX-NET_Main_340.onnx": {
     "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_340",
@@ -3680,8 +4545,39 @@
             "ISR": 19.1598
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.59047,
+            "SIR": 19.3254,
+            "SAR": 5.54795,
+            "ISR": 9.92554
+          },
+          "instrumental": {
+            "SDR": 16.5772,
+            "SIR": 24.8953,
+            "SAR": 19.8876,
+            "ISR": 18.9964
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 9.01994,
+        "SIR": 23.9804,
+        "SAR": 9.23348,
+        "ISR": 13.2887
+      },
+      "instrumental": {
+        "SDR": 16.5342,
+        "SIR": 26.6064,
+        "SAR": 19.4998,
+        "ISR": 19.0781
+      }
+    }
   },
   "UVR-MDX-NET_Main_390.onnx": {
     "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_390",
@@ -3702,8 +4598,39 @@
             "ISR": 18.6295
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 3.20541,
+            "SIR": 16.7913,
+            "SAR": 5.91045,
+            "ISR": 9.75897
+          },
+          "instrumental": {
+            "SDR": 12.3509,
+            "SIR": 18.2773,
+            "SAR": 15.1963,
+            "ISR": 17.5234
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 4.04885,
+        "SIR": 22.8324,
+        "SAR": 9.44913,
+        "ISR": 8.02524
+      },
+      "instrumental": {
+        "SDR": 10.6928,
+        "SIR": 13.7361,
+        "SAR": 15.2632,
+        "ISR": 18.0765
+      }
+    }
   },
   "UVR-MDX-NET_Main_406.onnx": {
     "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_406",
@@ -3724,8 +4651,39 @@
             "ISR": 19.1259
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.85269,
+            "SIR": 17.2346,
+            "SAR": 5.75262,
+            "ISR": 10.9493
+          },
+          "instrumental": {
+            "SDR": 16.5944,
+            "SIR": 26.387,
+            "SAR": 19.5127,
+            "ISR": 18.6513
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 9.2985,
+        "SIR": 22.7979,
+        "SAR": 9.41546,
+        "ISR": 14.5832
+      },
+      "instrumental": {
+        "SDR": 16.476,
+        "SIR": 27.8064,
+        "SAR": 19.3793,
+        "ISR": 18.8886
+      }
+    }
   },
   "UVR-MDX-NET_Main_427.onnx": {
     "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_427",
@@ -3746,8 +4704,39 @@
             "ISR": 19.2178
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.82906,
+            "SIR": 17.6647,
+            "SAR": 5.943,
+            "ISR": 10.1517
+          },
+          "instrumental": {
+            "SDR": 16.5208,
+            "SIR": 25.1407,
+            "SAR": 20.0019,
+            "ISR": 18.7475
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 9.07373,
+        "SIR": 23.3531,
+        "SAR": 9.513,
+        "ISR": 13.1689
+      },
+      "instrumental": {
+        "SDR": 16.5618,
+        "SIR": 26.5866,
+        "SAR": 19.7811,
+        "ISR": 18.9826
+      }
+    }
   },
   "UVR-MDX-NET_Main_438.onnx": {
     "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Main_438",
@@ -3768,8 +4757,39 @@
             "ISR": 19.1815
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.53862,
+            "SIR": 16.0907,
+            "SAR": 5.62231,
+            "ISR": 9.7587
+          },
+          "instrumental": {
+            "SDR": 16.5526,
+            "SIR": 24.6013,
+            "SAR": 19.8913,
+            "ISR": 18.7021
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.90576,
+        "SIR": 22.3737,
+        "SAR": 9.43196,
+        "ISR": 12.8374
+      },
+      "instrumental": {
+        "SDR": 16.5254,
+        "SIR": 26.0771,
+        "SAR": 19.7313,
+        "ISR": 18.9418
+      }
+    }
   },
   "UVR-MDX-NET_Inst_82_beta.onnx": {
     "model_name": "MDX-Net Model VIP: UVR-MDX-NET_Inst_82_beta",

--- a/audio_separator/models-scores.json
+++ b/audio_separator/models-scores.json
@@ -1,0 +1,266 @@
+{
+  "1_HP-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 1_HP-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.86522,
+            "SIR": 23.3587,
+            "SAR": 10.1785,
+            "ISR": 15.0739
+          },
+          "instrumental": {
+            "SDR": 15.7431,
+            "SIR": 20.9606,
+            "SAR": 17.3032,
+            "ISR": 29.0623
+          }
+        }
+      }
+    ]
+  },
+  "2_HP-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 2_HP-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.86277,
+            "SIR": 23.2713,
+            "SAR": 10.0964,
+            "ISR": 14.7435
+          },
+          "instrumental": {
+            "SDR": 15.4816,
+            "SIR": 20.1623,
+            "SAR": 17.3278,
+            "ISR": 28.9186
+          }
+        }
+      }
+    ]
+  },
+  "3_HP-Vocal-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 3_HP-Vocal-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.2015,
+            "SIR": 25.0552,
+            "SAR": 10.3513,
+            "ISR": 15.9666
+          },
+          "instrumental": {
+            "SDR": 16.2483,
+            "SIR": 21.8777,
+            "SAR": 17.4968,
+            "ISR": 30.7329
+          }
+        }
+      }
+    ]
+  },
+  "4_HP-Vocal-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 4_HP-Vocal-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 10.1621,
+            "SIR": 23.2506,
+            "SAR": 10.2838,
+            "ISR": 16.6347
+          },
+          "instrumental": {
+            "SDR": 15.8716,
+            "SIR": 22.3494,
+            "SAR": 17.176,
+            "ISR": 28.9295
+          }
+        }
+      }
+    ]
+  },
+  "5_HP-Karaoke-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 5_HP-Karaoke-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.3986,
+            "SIR": 23.8072,
+            "SAR": 9.52931,
+            "ISR": 13.2465
+          },
+          "instrumental": {
+            "SDR": 15.4412,
+            "SIR": 18.7661,
+            "SAR": 17.0021,
+            "ISR": 29.6517
+          }
+        }
+      }
+    ]
+  },
+  "6_HP-Karaoke-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 6_HP-Karaoke-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.62845,
+            "SIR": 24.0414,
+            "SAR": 9.55387,
+            "ISR": 13.5417
+          },
+          "instrumental": {
+            "SDR": 15.6841,
+            "SIR": 19.0452,
+            "SAR": 17.1219,
+            "ISR": 31.5764
+          }
+        }
+      }
+    ]
+  },
+  "7_HP2-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 7_HP2-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.9246,
+            "SIR": 23.9273,
+            "SAR": 10.3074,
+            "ISR": 14.8333
+          },
+          "instrumental": {
+            "SDR": 15.7343,
+            "SIR": 20.1956,
+            "SAR": 17.6699,
+            "ISR": 31.2578
+          }
+        }
+      }
+    ]
+  },
+  "8_HP2-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 8_HP2-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.94006,
+            "SIR": 23.715,
+            "SAR": 10.3701,
+            "ISR": 14.653
+          },
+          "instrumental": {
+            "SDR": 15.5981,
+            "SIR": 20.4122,
+            "SAR": 17.3973,
+            "ISR": 29.4197
+          }
+        }
+      }
+    ]
+  },
+  "9_HP2-UVR.pth": {
+    "model_name": "VR Arch Single Model v5: 9_HP2-UVR",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.89634,
+            "SIR": 23.8526,
+            "SAR": 10.3504,
+            "ISR": 14.5682
+          },
+          "instrumental": {
+            "SDR": 15.7111,
+            "SIR": 20.3581,
+            "SAR": 17.6392,
+            "ISR": 29.5016
+          }
+        }
+      }
+    ]
+  },
+  "10_SP-UVR-2B-32000-1.pth": {
+    "model_name": "VR Arch Single Model v5: 10_SP-UVR-2B-32000-1",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.54673,
+            "SIR": 23.3362,
+            "SAR": 9.91098,
+            "ISR": 13.8572
+          },
+          "instrumental": {
+            "SDR": 15.0055,
+            "SIR": 19.9132,
+            "SAR": 16.537,
+            "ISR": 23.2056
+          }
+        }
+      }
+    ]
+  },
+  "11_SP-UVR-2B-32000-2.pth": {
+    "model_name": "VR Arch Single Model v5: 11_SP-UVR-2B-32000-2",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.52838,
+            "SIR": 23.6181,
+            "SAR": 9.90405,
+            "ISR": 13.8069
+          },
+          "instrumental": {
+            "SDR": 15.0352,
+            "SIR": 19.8583,
+            "SAR": 16.5648,
+            "ISR": 23.329
+          }
+        }
+      }
+    ]
+  },
+  "12_SP-UVR-3B-44100.pth": {
+    "model_name": "VR Arch Single Model v5: 12_SP-UVR-3B-44100",
+    "track_scores": [
+      {
+        "track_name": "Moosmusic - Big Dummy Shake",
+        "scores": {
+          "vocals": {
+            "SDR": 9.70757,
+            "SIR": 23.4678,
+            "SAR": 10.1294,
+            "ISR": 14.3904
+          },
+          "instrumental": {
+            "SDR": 15.2341,
+            "SIR": 20.0053,
+            "SAR": 17.2023,
+            "ISR": 28.5095
+          }
+        }
+      }
+    ]
+  }
+}

--- a/audio_separator/models-scores.json
+++ b/audio_separator/models-scores.json
@@ -11,7 +11,7 @@
             "SAR": 10.1785,
             "ISR": 15.0739
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.7431,
             "SIR": 20.9606,
             "SAR": 17.3032,
@@ -28,7 +28,7 @@
             "SAR": 4.83391,
             "ISR": 8.8857
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.8927,
             "SIR": 19.3158,
             "SAR": 18.24,
@@ -45,7 +45,7 @@
             "SAR": 5.75084,
             "ISR": 12.7187
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.6068,
             "SIR": 18.0944,
             "SAR": 12.3348,
@@ -62,7 +62,7 @@
             "SAR": 8.54122,
             "ISR": 15.3526
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.3357,
             "SIR": 21.73,
             "SAR": 16.6099,
@@ -79,7 +79,7 @@
             "SAR": 4.00494,
             "ISR": 12.7504
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.3974,
             "SIR": 21.6121,
             "SAR": 13.2817,
@@ -96,7 +96,7 @@
             "SAR": 9.60245,
             "ISR": 13.3208
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.781,
             "SIR": 15.3895,
             "SAR": 13.3742,
@@ -113,7 +113,7 @@
             "SAR": 9.47788,
             "ISR": 13.4743
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.0084,
             "SIR": 15.7127,
             "SAR": 12.9399,
@@ -130,7 +130,7 @@
             "SAR": 10.333,
             "ISR": 14.4066
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.318,
             "SIR": 18.8837,
             "SAR": 15.8694,
@@ -147,7 +147,7 @@
             "SAR": 5.93576,
             "ISR": 10.5446
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 17.9788,
             "SIR": 23.2555,
             "SAR": 21.5719,
@@ -164,7 +164,7 @@
             "SAR": 9.99461,
             "ISR": 12.9868
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.4142,
             "SIR": 16.693,
             "SAR": 15.1214,
@@ -181,7 +181,7 @@
             "SAR": 7.57484,
             "ISR": 10.4891
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.3057,
             "SIR": 14.2951,
             "SAR": 13.8743,
@@ -198,7 +198,7 @@
             "SAR": 10.6547,
             "ISR": 17.3402
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.2878,
             "SIR": 20.8786,
             "SAR": 14.4586,
@@ -215,7 +215,7 @@
             "SAR": 9.75169,
             "ISR": 15.2152
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.9512,
             "SIR": 21.3993,
             "SAR": 16.138,
@@ -232,7 +232,7 @@
             "SAR": 6.98892,
             "ISR": 12.3147
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.8124,
             "SIR": 20.1259,
             "SAR": 15.7944,
@@ -249,7 +249,7 @@
             "SAR": 7.8475,
             "ISR": 13.134
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.5321,
             "SIR": 20.5767,
             "SAR": 16.245,
@@ -266,7 +266,7 @@
             "SAR": 3.3243,
             "ISR": 7.31346
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.8819,
             "SIR": 17.3794,
             "SAR": 18.4389,
@@ -283,7 +283,7 @@
             "SAR": 8.72244,
             "ISR": 14.1103
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.3555,
             "SIR": 18.9906,
             "SAR": 15.1787,
@@ -300,7 +300,7 @@
             "SAR": 6.83054,
             "ISR": 10.5802
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.7255,
             "SIR": 17.3371,
             "SAR": 16.0628,
@@ -317,7 +317,7 @@
             "SAR": 0.60976,
             "ISR": 0.2973
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.6498,
             "SIR": 49.0042,
             "SAR": 12.4641,
@@ -334,7 +334,7 @@
             "SAR": 5.40936,
             "ISR": 8.49432
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.2047,
             "SIR": 17.0075,
             "SAR": 16.996,
@@ -351,7 +351,7 @@
             "SAR": 8.74048,
             "ISR": 13.0896
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.9941,
             "SIR": 19.1888,
             "SAR": 16.7467,
@@ -368,7 +368,7 @@
             "SAR": 9.75759,
             "ISR": 14.2486
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 18.8229,
             "SIR": 25.0371,
             "SAR": 19.7476,
@@ -385,7 +385,7 @@
             "SAR": 6.0561,
             "ISR": 11.368
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.8085,
             "SIR": 17.9619,
             "SAR": 15.7333,
@@ -402,7 +402,7 @@
             "SAR": 3.17736,
             "ISR": 5.63786
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.3255,
             "SIR": 12.4029,
             "SAR": 15.0933,
@@ -419,7 +419,7 @@
             "SAR": 5.73903,
             "ISR": 9.24557
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.975,
             "SIR": 19.4188,
             "SAR": 17.948,
@@ -436,7 +436,7 @@
             "SAR": 6.30036,
             "ISR": 10.0651
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.1405,
             "SIR": 18.0741,
             "SAR": 16.8313,
@@ -453,7 +453,7 @@
             "SAR": 7.46711,
             "ISR": 13.4299
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.0101,
             "SIR": 18.3,
             "SAR": 14.5392,
@@ -470,7 +470,7 @@
             "SAR": 8.23403,
             "ISR": 11.5089
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.76063,
             "SIR": 13.0942,
             "SAR": 11.6006,
@@ -487,7 +487,7 @@
             "SAR": 3.94581,
             "ISR": 8.26944
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.3109,
             "SIR": 12.6439,
             "SAR": 12.5739,
@@ -504,7 +504,7 @@
             "SAR": 9.30687,
             "ISR": 13.3151
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.8668,
             "SIR": 18.001,
             "SAR": 15.5456,
@@ -521,7 +521,7 @@
             "SAR": 10.58,
             "ISR": 13.4283
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.5839,
             "SIR": 13.1001,
             "SAR": 10.4395,
@@ -538,7 +538,7 @@
             "SAR": 10.0456,
             "ISR": 13.8778
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.7055,
             "SIR": 16.7757,
             "SAR": 13.7724,
@@ -555,7 +555,7 @@
             "SAR": 10.9111,
             "ISR": 15.3985
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.1001,
             "SIR": 22.8839,
             "SAR": 19.7081,
@@ -572,7 +572,7 @@
             "SAR": 4.81204,
             "ISR": 8.86849
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.9125,
             "SIR": 14.02,
             "SAR": 12.4588,
@@ -589,7 +589,7 @@
             "SAR": 12.6541,
             "ISR": 21.4862
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 20.8791,
             "SIR": 29.5482,
             "SAR": 21.5446,
@@ -606,7 +606,7 @@
             "SAR": 11.3987,
             "ISR": 18.4367
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.827,
             "SIR": 17.4836,
             "SAR": 11.1509,
@@ -623,7 +623,7 @@
             "SAR": 6.55888,
             "ISR": 10.6605
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.4443,
             "SIR": 15.754,
             "SAR": 13.6843,
@@ -640,7 +640,7 @@
             "SAR": 5.2702,
             "ISR": 12.1
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.2903,
             "SIR": 22.4148,
             "SAR": 17.1974,
@@ -657,7 +657,7 @@
             "SAR": 8.3819,
             "ISR": 13.277
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.2919,
             "SIR": 20.1393,
             "SAR": 17.1399,
@@ -674,7 +674,7 @@
             "SAR": 9.61721,
             "ISR": 13.4541
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.8108,
             "SIR": 21.3215,
             "SAR": 18.4017,
@@ -691,7 +691,7 @@
             "SAR": 8.69275,
             "ISR": 13.1925
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.2943,
             "SIR": 16.7404,
             "SAR": 13.7403,
@@ -708,7 +708,7 @@
             "SAR": 8.24112,
             "ISR": 12.8178
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.483,
             "SIR": 19.329,
             "SAR": 16.6609,
@@ -725,7 +725,7 @@
             "SAR": 10.8092,
             "ISR": 15.8994
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.725,
             "SIR": 19.4409,
             "SAR": 15.7471,
@@ -742,7 +742,7 @@
             "SAR": 10.07,
             "ISR": 14.3834
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.0804,
             "SIR": 20.7322,
             "SAR": 17.8891,
@@ -759,7 +759,7 @@
             "SAR": 12.1773,
             "ISR": 18.1952
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.2837,
             "SIR": 19.6038,
             "SAR": 13.4421,
@@ -776,7 +776,7 @@
             "SAR": 8.89653,
             "ISR": 13.1717
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.3783,
             "SIR": 19.3105,
             "SAR": 16.252,
@@ -793,7 +793,7 @@
             "SAR": 7.9146,
             "ISR": 11.7854
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.2398,
             "SIR": 18.7184,
             "SAR": 16.864,
@@ -810,7 +810,7 @@
             "SAR": 9.1738,
             "ISR": 12.7127
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.2422,
             "SIR": 16.3424,
             "SAR": 14.3325,
@@ -827,7 +827,7 @@
             "SAR": 8.42697,
             "ISR": 13.5337
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.1428,
             "SIR": 22.4261,
             "SAR": 19.1421,
@@ -844,7 +844,7 @@
             "SAR": 8.67582,
             "ISR": 14.5572
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.6138,
             "SIR": 21.2583,
             "SAR": 16.4567,
@@ -861,7 +861,7 @@
             "SAR": 9.7305,
             "ISR": 14.4864
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.0164,
             "SIR": 21.0056,
             "SAR": 17.5031,
@@ -878,7 +878,7 @@
             "SAR": 0.73314,
             "ISR": 9.64777
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 17.1617,
             "SIR": 28.8821,
             "SAR": 18.6928,
@@ -895,7 +895,7 @@
             "SAR": 9.90282,
             "ISR": 17.2928
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.5695,
             "SIR": 22.5407,
             "SAR": 16.3144,
@@ -912,7 +912,7 @@
             "SAR": 9.41665,
             "ISR": 15.0012
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.6015,
             "SIR": 21.3811,
             "SAR": 17.4448,
@@ -929,7 +929,7 @@
             "SAR": 9.83085,
             "ISR": 17.0117
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.0332,
             "SIR": 19.9729,
             "SAR": 15.4035,
@@ -946,7 +946,7 @@
             "SAR": 13.3524,
             "ISR": 17.794
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.0297,
             "SIR": 20.4311,
             "SAR": 16.818,
@@ -963,7 +963,7 @@
             "SAR": 9.37779,
             "ISR": 14.441
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.1579,
             "SIR": 20.0639,
             "SAR": 16.8333,
@@ -980,7 +980,7 @@
             "SAR": 8.41092,
             "ISR": 12.2971
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.7304,
             "SIR": 15.3465,
             "SAR": 14.038,
@@ -997,7 +997,7 @@
             "SAR": 12.2027,
             "ISR": 17.7826
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.8592,
             "SIR": 19.9921,
             "SAR": 15.5003,
@@ -1014,7 +1014,7 @@
             "SAR": 15.7425,
             "ISR": 23.2008
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 17.8599,
             "SIR": 26.9764,
             "SAR": 18.6755,
@@ -1031,7 +1031,7 @@
             "SAR": 14.1504,
             "ISR": 21.2015
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 17.1899,
             "SIR": 25.1109,
             "SAR": 18.1604,
@@ -1048,7 +1048,7 @@
             "SAR": 17.7841,
             "ISR": 23.8337
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.28,
             "SIR": 24.6295,
             "SAR": 17.1943,
@@ -1065,7 +1065,7 @@
             "SAR": 9.01484,
             "ISR": 13.561
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.5417,
             "SIR": 19.3548,
             "SAR": 15.7758,
@@ -1082,7 +1082,7 @@
             "SAR": 10.6214,
             "ISR": 18.1688
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.1538,
             "SIR": 23.2521,
             "SAR": 15.0103,
@@ -1099,7 +1099,7 @@
             "SAR": 11.0108,
             "ISR": 14.5884
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.3328,
             "SIR": 18.4485,
             "SAR": 15.7827,
@@ -1116,7 +1116,7 @@
             "SAR": 16.517,
             "ISR": 23.145
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 18.075,
             "SIR": 27.8346,
             "SAR": 20.9546,
@@ -1133,7 +1133,7 @@
             "SAR": 10.8346,
             "ISR": 14.7617
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.6692,
             "SIR": 15.6967,
             "SAR": 12.8753,
@@ -1150,7 +1150,7 @@
             "SAR": 11.056,
             "ISR": 15.2638
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.9873,
             "SIR": 18.527,
             "SAR": 14.6569,
@@ -1167,7 +1167,7 @@
             "SAR": 8.92555,
             "ISR": 13.1305
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.0227,
             "SIR": 14.5853,
             "SAR": 11.2098,
@@ -1184,7 +1184,7 @@
             "SAR": 8.11735,
             "ISR": 13.1519
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.9056,
             "SIR": 17.939,
             "SAR": 15.3045,
@@ -1201,7 +1201,7 @@
             "SAR": 11.019,
             "ISR": 15.3817
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.2429,
             "SIR": 16.4682,
             "SAR": 13.4563,
@@ -1218,7 +1218,7 @@
             "SAR": 10.2048,
             "ISR": 15.0192
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.6941,
             "SIR": 14.3762,
             "SAR": 11.5214,
@@ -1235,7 +1235,7 @@
             "SAR": 10.8028,
             "ISR": 14.806
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.1948,
             "SIR": 21.7629,
             "SAR": 18.5402,
@@ -1252,7 +1252,7 @@
             "SAR": 3.59386,
             "ISR": 9.77711
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.87824,
             "SIR": 18.1847,
             "SAR": 11.5932,
@@ -1269,7 +1269,7 @@
             "SAR": 7.88169,
             "ISR": 11.7645
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.8007,
             "SIR": 15.7143,
             "SAR": 14.1137,
@@ -1286,7 +1286,7 @@
             "SAR": 4.12566,
             "ISR": 9.67366
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.0714,
             "SIR": 18.9577,
             "SAR": 16.0332,
@@ -1303,7 +1303,7 @@
             "SAR": 6.25407,
             "ISR": 11.3342
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.1445,
             "SIR": 21.3697,
             "SAR": 18.5304,
@@ -1320,7 +1320,7 @@
             "SAR": 4e-05,
             "ISR": 2.15205
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 22.6053,
             "SIR": 42.7372,
             "SAR": 28.4098,
@@ -1337,7 +1337,7 @@
             "SAR": 5.90764,
             "ISR": 8.694
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.172,
             "SIR": 17.8467,
             "SAR": 17.6432,
@@ -1354,7 +1354,7 @@
             "SAR": 7.18892,
             "ISR": 11.9632
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.0824,
             "SIR": 16.9623,
             "SAR": 14.7653,
@@ -1371,7 +1371,7 @@
             "SAR": 9.93457,
             "ISR": 16.1074
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.2343,
             "SIR": 17.0765,
             "SAR": 12.1632,
@@ -1388,7 +1388,7 @@
             "SAR": 5.33354,
             "ISR": 8.94768
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.2133,
             "SIR": 13.9609,
             "SAR": 13.7129,
@@ -1405,7 +1405,7 @@
             "SAR": 5.7076,
             "ISR": 11.3702
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.7736,
             "SIR": 16.5125,
             "SAR": 14.0172,
@@ -1422,7 +1422,7 @@
             "SAR": 5.62667,
             "ISR": 8.67216
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 8.20879,
             "SIR": 10.4055,
             "SAR": 11.2874,
@@ -1439,7 +1439,7 @@
             "SAR": 4.73126,
             "ISR": 9.19776
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.9223,
             "SIR": 16.9377,
             "SAR": 14.8289,
@@ -1456,7 +1456,7 @@
             "SAR": 8.73839,
             "ISR": 15.3652
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.4927,
             "SIR": 16.5549,
             "SAR": 11.3729,
@@ -1473,7 +1473,7 @@
             "SAR": 9.33408,
             "ISR": 13.6103
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.706,
             "SIR": 18.8497,
             "SAR": 16.8638,
@@ -1490,7 +1490,7 @@
             "SAR": 7.65666,
             "ISR": 11.4719
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.4334,
             "SIR": 14.1601,
             "SAR": 12.6401,
@@ -1507,7 +1507,7 @@
             "SAR": 6.15763,
             "ISR": 10.8781
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.8646,
             "SIR": 16.8644,
             "SAR": 14.4989,
@@ -1524,7 +1524,7 @@
             "SAR": 11.9686,
             "ISR": 17.3157
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.6624,
             "SIR": 20.5838,
             "SAR": 16.1242,
@@ -1541,7 +1541,7 @@
             "SAR": 5.91303,
             "ISR": 10.3718
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.57475,
             "SIR": 11.8168,
             "SAR": 10.4881,
@@ -1558,7 +1558,7 @@
             "SAR": 4.45802,
             "ISR": 6.82841
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.0317,
             "SIR": 13.008,
             "SAR": 15.404,
@@ -1575,7 +1575,7 @@
             "SAR": 6.04031,
             "ISR": 9.59568
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.7515,
             "SIR": 16.6174,
             "SAR": 16.1713,
@@ -1592,7 +1592,7 @@
             "SAR": 5.51779,
             "ISR": 9.32155
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.2745,
             "SIR": 13.0619,
             "SAR": 12.7821,
@@ -1609,7 +1609,7 @@
             "SAR": 9.03124,
             "ISR": 13.7485
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.2972,
             "SIR": 16.4494,
             "SAR": 13.7676,
@@ -1626,7 +1626,7 @@
             "SAR": 10.3282,
             "ISR": 15.2514
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.612,
             "SIR": 17.1297,
             "SAR": 13.0885,
@@ -1643,7 +1643,7 @@
             "SAR": 5.42572,
             "ISR": 8.42458
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 8.83652,
             "SIR": 11.2361,
             "SAR": 11.5247,
@@ -1660,7 +1660,7 @@
             "SAR": 4.63136,
             "ISR": 8.5076
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.6727,
             "SIR": 19.014,
             "SAR": 18.4964,
@@ -1677,7 +1677,7 @@
             "SAR": 8.10088,
             "ISR": 13.2098
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.597,
             "SIR": 20.6947,
             "SAR": 17.6958,
@@ -1694,7 +1694,7 @@
             "SAR": 9.21459,
             "ISR": 13.9706
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.8753,
             "SIR": 17.7815,
             "SAR": 14.3314,
@@ -1711,7 +1711,7 @@
             "SAR": 8.45981,
             "ISR": 13.2456
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.295,
             "SIR": 18.9764,
             "SAR": 16.0033,
@@ -1728,7 +1728,7 @@
             "SAR": 11.3157,
             "ISR": 16.7876
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.8578,
             "SIR": 22.6781,
             "SAR": 18.2187,
@@ -1745,7 +1745,7 @@
             "SAR": 7.46094,
             "ISR": 10.9252
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.44502,
             "SIR": 11.724,
             "SAR": 11.0882,
@@ -1762,7 +1762,7 @@
             "SAR": 9.49863,
             "ISR": 14.8275
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.9674,
             "SIR": 18.8805,
             "SAR": 14.1361,
@@ -1779,7 +1779,7 @@
             "SAR": 9.12358,
             "ISR": 13.5951
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.928,
             "SIR": 22.8837,
             "SAR": 19.55,
@@ -1796,7 +1796,7 @@
             "SAR": 8.11272,
             "ISR": 12.5669
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.0931,
             "SIR": 19.7735,
             "SAR": 16.7143,
@@ -1813,7 +1813,7 @@
             "SAR": 11.1524,
             "ISR": 16.409
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.6933,
             "SIR": 20.4239,
             "SAR": 16.0864,
@@ -1830,7 +1830,7 @@
             "SAR": 5.01273,
             "ISR": 8.69419
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.264,
             "SIR": 15.0653,
             "SAR": 15.3341,
@@ -1847,7 +1847,7 @@
             "SAR": 8.72368,
             "ISR": 13.7476
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.4868,
             "SIR": 18.8872,
             "SAR": 15.3071,
@@ -1864,7 +1864,7 @@
             "SAR": 4.87802,
             "ISR": 8.83604
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.3411,
             "SIR": 18.0501,
             "SAR": 16.5105,
@@ -1881,7 +1881,7 @@
             "SAR": 6.3358,
             "ISR": 10.4418
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.84974,
             "SIR": 11.8716,
             "SAR": 10.907,
@@ -1898,7 +1898,7 @@
             "SAR": 10.4012,
             "ISR": 13.8744
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.4474,
             "SIR": 17.7872,
             "SAR": 15.6015,
@@ -1915,7 +1915,7 @@
             "SAR": 10.9819,
             "ISR": 16.5344
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.6667,
             "SIR": 20.0484,
             "SAR": 14.8253,
@@ -1932,7 +1932,7 @@
             "SAR": 0.65766,
             "ISR": -4.79845
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.1948,
             "SIR": -0.59224,
             "SAR": 2.70242,
@@ -1949,7 +1949,7 @@
             "SAR": 7.69145,
             "ISR": 12.1834
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 13.9493,
             "SIR": 18.08,
             "SAR": 16.1657,
@@ -1966,7 +1966,7 @@
             "SAR": 6.52708,
             "ISR": 10.8173
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 10.9079,
             "SIR": 14.7493,
             "SAR": 13.2028,
@@ -1983,7 +1983,7 @@
             "SAR": 4.92282,
             "ISR": 8.4244
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 12.58,
             "SIR": 16.4122,
             "SAR": 15.414,
@@ -2000,7 +2000,7 @@
             "SAR": 7.75084,
             "ISR": 12.5441
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.917,
             "SIR": 21.5775,
             "SAR": 18.6675,
@@ -2017,7 +2017,7 @@
             "SAR": 7.35798,
             "ISR": 11.4437
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 11.5592,
             "SIR": 14.4729,
             "SAR": 13.85,
@@ -2034,15 +2034,216 @@
             "SAR": 9.82067,
             "ISR": 14.9712
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.8317,
             "SIR": 21.8122,
             "SAR": 18.5105,
             "ISR": 31.3298
           }
         }
+      },
+      {
+        "track_name": "Little Chicago's Finest - My Own",
+        "scores": {
+          "vocals": {
+            "SDR": 11.5171,
+            "SIR": 21.7311,
+            "SAR": 12.0017,
+            "ISR": 17.6887
+          },
+          "instrumental": {
+            "SDR": 2.33264,
+            "SIR": 20.0894,
+            "SAR": 12.5567,
+            "ISR": 2.54557
+          }
+        }
+      },
+      {
+        "track_name": "Louis Cressy Band - Good Time",
+        "scores": {
+          "vocals": {
+            "SDR": 8.13776,
+            "SIR": 21.2328,
+            "SAR": 8.11081,
+            "ISR": 13.2834
+          },
+          "instrumental": {
+            "SDR": 12.6674,
+            "SIR": 17.6774,
+            "SAR": 13.8957,
+            "ISR": 27.2611
+          }
+        }
+      },
+      {
+        "track_name": "Lyndsey Ollard - Catching Up",
+        "scores": {
+          "vocals": {
+            "SDR": 10.8529,
+            "SIR": 25.7526,
+            "SAR": 9.9038,
+            "ISR": 12.2732
+          },
+          "instrumental": {
+            "SDR": 13.6804,
+            "SIR": 14.7845,
+            "SAR": 14.3482,
+            "ISR": 26.7593
+          }
+        }
+      },
+      {
+        "track_name": "M.E.R.C. Music - Knockout",
+        "scores": {
+          "vocals": {
+            "SDR": 10.5907,
+            "SIR": 19.7494,
+            "SAR": 10.7183,
+            "ISR": 16.1546
+          },
+          "instrumental": {
+            "SDR": 12.5385,
+            "SIR": 17.5308,
+            "SAR": 13.0735,
+            "ISR": 22.0308
+          }
+        }
+      },
+      {
+        "track_name": "Motor Tapes - Shore",
+        "scores": {
+          "vocals": {
+            "SDR": 6.5468,
+            "SIR": 16.8979,
+            "SAR": 6.61397,
+            "ISR": 12.9613
+          },
+          "instrumental": {
+            "SDR": 13.4085,
+            "SIR": 18.9175,
+            "SAR": 15.596,
+            "ISR": 24.7072
+          }
+        }
+      },
+      {
+        "track_name": "Mu - Too Bright",
+        "scores": {
+          "vocals": {
+            "SDR": 9.29134,
+            "SIR": 19.4112,
+            "SAR": 9.71407,
+            "ISR": 16.0865
+          },
+          "instrumental": {
+            "SDR": 14.4919,
+            "SIR": 21.6881,
+            "SAR": 16.3609,
+            "ISR": 19.0402
+          }
+        }
+      },
+      {
+        "track_name": "Nerve 9 - Pray For The Rain",
+        "scores": {
+          "vocals": {
+            "SDR": 8.29469,
+            "SIR": 22.4624,
+            "SAR": 8.33514,
+            "ISR": 11.3729
+          },
+          "instrumental": {
+            "SDR": 12.8854,
+            "SIR": 14.4035,
+            "SAR": 13.1331,
+            "ISR": 25.3699
+          }
+        }
+      },
+      {
+        "track_name": "PR - Happy Daze",
+        "scores": {
+          "vocals": {
+            "SDR": 0.22666,
+            "SIR": 9.36198,
+            "SAR": 0.22112,
+            "ISR": 2.4467
+          },
+          "instrumental": {
+            "SDR": 20.3778,
+            "SIR": 43.5134,
+            "SAR": 40.8867,
+            "ISR": 20.4509
+          }
+        }
+      },
+      {
+        "track_name": "PR - Oh No",
+        "scores": {
+          "vocals": {
+            "SDR": -2e-05,
+            "SIR": 8.00312,
+            "SAR": -0.00177,
+            "ISR": 1.59044
+          },
+          "instrumental": {
+            "SDR": 8.63339,
+            "SIR": 33.137,
+            "SAR": 19.717,
+            "ISR": 8.9836
+          }
+        }
+      },
+      {
+        "track_name": "Punkdisco - Oral Hygiene",
+        "scores": {
+          "vocals": {
+            "SDR": 8.74866,
+            "SIR": 24.3287,
+            "SAR": 9.21975,
+            "ISR": 16.0094
+          },
+          "instrumental": {
+            "SDR": 17.8085,
+            "SIR": 27.1854,
+            "SAR": 21.2874,
+            "ISR": 20.5462
+          }
+        }
+      },
+      {
+        "track_name": "Raft Monk - Tiring",
+        "scores": {
+          "vocals": {
+            "SDR": 5.4833,
+            "SIR": 13.5775,
+            "SAR": 5.95863,
+            "ISR": 8.83895
+          },
+          "instrumental": {
+            "SDR": 12.172,
+            "SIR": 15.2582,
+            "SAR": 15.3302,
+            "ISR": 22.888
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 8.2519,
+        "SIR": 19.4112,
+        "SAR": 8.45981,
+        "ISR": 13.1717
+      },
+      "instrumental": {
+        "SDR": 13.4868,
+        "SIR": 18.7184,
+        "SAR": 15.5456,
+        "ISR": 21.9107
+      }
+    }
   },
   "2_HP-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 2_HP-UVR",
@@ -2056,15 +2257,46 @@
             "SAR": 10.0964,
             "ISR": 14.7435
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.4816,
             "SIR": 20.1623,
             "SAR": 17.3278,
             "ISR": 28.9186
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.00778,
+            "SIR": 16.5022,
+            "SAR": 4.95801,
+            "ISR": 9.04026
+          },
+          "instrumental": {
+            "SDR": 14.9485,
+            "SIR": 20.0149,
+            "SAR": 19.0058,
+            "ISR": 18.6304
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.43527,
+        "SIR": 19.8867,
+        "SAR": 7.5272,
+        "ISR": 11.8919
+      },
+      "instrumental": {
+        "SDR": 15.215,
+        "SIR": 20.0886,
+        "SAR": 18.1668,
+        "ISR": 23.7745
+      }
+    }
   },
   "3_HP-Vocal-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 3_HP-Vocal-UVR",
@@ -2078,15 +2310,46 @@
             "SAR": 10.3513,
             "ISR": 15.9666
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.2483,
             "SIR": 21.8777,
             "SAR": 17.4968,
             "ISR": 30.7329
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 3.91517,
+            "SIR": 16.8581,
+            "SAR": 3.2452,
+            "ISR": 8.16718
+          },
+          "instrumental": {
+            "SDR": 15.4662,
+            "SIR": 20.2019,
+            "SAR": 18.6457,
+            "ISR": 19.0081
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.05833,
+        "SIR": 20.9566,
+        "SAR": 6.79825,
+        "ISR": 12.0669
+      },
+      "instrumental": {
+        "SDR": 15.8573,
+        "SIR": 21.0398,
+        "SAR": 18.0712,
+        "ISR": 24.8705
+      }
+    }
   },
   "4_HP-Vocal-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 4_HP-Vocal-UVR",
@@ -2100,15 +2363,46 @@
             "SAR": 10.2838,
             "ISR": 16.6347
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.8716,
             "SIR": 22.3494,
             "SAR": 17.176,
             "ISR": 28.9295
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.13247,
+            "SIR": 15.6369,
+            "SAR": 4.46161,
+            "ISR": 9.59156
+          },
+          "instrumental": {
+            "SDR": 14.9272,
+            "SIR": 20.4818,
+            "SAR": 17.6023,
+            "ISR": 18.6389
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.64729,
+        "SIR": 19.4438,
+        "SAR": 7.3727,
+        "ISR": 13.1131
+      },
+      "instrumental": {
+        "SDR": 15.3994,
+        "SIR": 21.4156,
+        "SAR": 17.3892,
+        "ISR": 23.7842
+      }
+    }
   },
   "5_HP-Karaoke-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 5_HP-Karaoke-UVR",
@@ -2122,15 +2416,46 @@
             "SAR": 9.52931,
             "ISR": 13.2465
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.4412,
             "SIR": 18.7661,
             "SAR": 17.0021,
             "ISR": 29.6517
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 2.37002,
+            "SIR": 20.6581,
+            "SAR": 1.28458,
+            "ISR": 4.10107
+          },
+          "instrumental": {
+            "SDR": 14.9129,
+            "SIR": 15.7183,
+            "SAR": 20.1,
+            "ISR": 19.509
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 5.88431,
+        "SIR": 22.2326,
+        "SAR": 5.40695,
+        "ISR": 8.67378
+      },
+      "instrumental": {
+        "SDR": 15.1771,
+        "SIR": 17.2422,
+        "SAR": 18.5511,
+        "ISR": 24.5804
+      }
+    }
   },
   "6_HP-Karaoke-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 6_HP-Karaoke-UVR",
@@ -2144,15 +2469,46 @@
             "SAR": 9.55387,
             "ISR": 13.5417
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.6841,
             "SIR": 19.0452,
             "SAR": 17.1219,
             "ISR": 31.5764
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 2.40569,
+            "SIR": 22.1346,
+            "SAR": 0.01828,
+            "ISR": 4.20645
+          },
+          "instrumental": {
+            "SDR": 14.9884,
+            "SIR": 15.2129,
+            "SAR": 19.224,
+            "ISR": 19.398
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.01707,
+        "SIR": 23.088,
+        "SAR": 4.78608,
+        "ISR": 8.87408
+      },
+      "instrumental": {
+        "SDR": 15.3362,
+        "SIR": 17.129,
+        "SAR": 18.173,
+        "ISR": 25.4872
+      }
+    }
   },
   "7_HP2-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 7_HP2-UVR",
@@ -2166,15 +2522,46 @@
             "SAR": 10.3074,
             "ISR": 14.8333
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.7343,
             "SIR": 20.1956,
             "SAR": 17.6699,
             "ISR": 31.2578
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.93236,
+            "SIR": 17.387,
+            "SAR": 4.36463,
+            "ISR": 8.40421
+          },
+          "instrumental": {
+            "SDR": 15.0848,
+            "SIR": 19.1375,
+            "SAR": 18.9953,
+            "ISR": 18.7277
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.42848,
+        "SIR": 20.6572,
+        "SAR": 7.33601,
+        "ISR": 11.6188
+      },
+      "instrumental": {
+        "SDR": 15.4095,
+        "SIR": 19.6666,
+        "SAR": 18.3326,
+        "ISR": 24.9928
+      }
+    }
   },
   "8_HP2-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 8_HP2-UVR",
@@ -2188,15 +2575,46 @@
             "SAR": 10.3701,
             "ISR": 14.653
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.5981,
             "SIR": 20.4122,
             "SAR": 17.3973,
             "ISR": 29.4197
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.5483,
+            "SIR": 18.0967,
+            "SAR": 4.25896,
+            "ISR": 7.83695
+          },
+          "instrumental": {
+            "SDR": 15.0298,
+            "SIR": 18.8059,
+            "SAR": 19.0634,
+            "ISR": 19.0558
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.24418,
+        "SIR": 20.9059,
+        "SAR": 7.31453,
+        "ISR": 11.245
+      },
+      "instrumental": {
+        "SDR": 15.314,
+        "SIR": 19.609,
+        "SAR": 18.2304,
+        "ISR": 24.2377
+      }
+    }
   },
   "9_HP2-UVR.pth": {
     "model_name": "VR Arch Single Model v5: 9_HP2-UVR",
@@ -2210,15 +2628,46 @@
             "SAR": 10.3504,
             "ISR": 14.5682
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.7111,
             "SIR": 20.3581,
             "SAR": 17.6392,
             "ISR": 29.5016
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 5.22431,
+            "SIR": 18.2506,
+            "SAR": 4.90021,
+            "ISR": 8.40822
+          },
+          "instrumental": {
+            "SDR": 15.1383,
+            "SIR": 19.3881,
+            "SAR": 19.1667,
+            "ISR": 19.0479
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.56033,
+        "SIR": 21.0516,
+        "SAR": 7.62531,
+        "ISR": 11.4882
+      },
+      "instrumental": {
+        "SDR": 15.4247,
+        "SIR": 19.8731,
+        "SAR": 18.4029,
+        "ISR": 24.2747
+      }
+    }
   },
   "10_SP-UVR-2B-32000-1.pth": {
     "model_name": "VR Arch Single Model v5: 10_SP-UVR-2B-32000-1",
@@ -2232,15 +2681,46 @@
             "SAR": 9.91098,
             "ISR": 13.8572
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.0055,
             "SIR": 19.9132,
             "SAR": 16.537,
             "ISR": 23.2056
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.55666,
+            "SIR": 13.1594,
+            "SAR": 4.60601,
+            "ISR": 8.92065
+          },
+          "instrumental": {
+            "SDR": 15.0844,
+            "SIR": 20.3956,
+            "SAR": 18.4196,
+            "ISR": 18.3987
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.0517,
+        "SIR": 18.2478,
+        "SAR": 7.25849,
+        "ISR": 11.3889
+      },
+      "instrumental": {
+        "SDR": 15.045,
+        "SIR": 20.1544,
+        "SAR": 17.4783,
+        "ISR": 20.8022
+      }
+    }
   },
   "11_SP-UVR-2B-32000-2.pth": {
     "model_name": "VR Arch Single Model v5: 11_SP-UVR-2B-32000-2",
@@ -2254,15 +2734,46 @@
             "SAR": 9.90405,
             "ISR": 13.8069
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.0352,
             "SIR": 19.8583,
             "SAR": 16.5648,
             "ISR": 23.329
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.38186,
+            "SIR": 13.6055,
+            "SAR": 4.31086,
+            "ISR": 8.63485
+          },
+          "instrumental": {
+            "SDR": 15.3254,
+            "SIR": 20.4471,
+            "SAR": 19.4538,
+            "ISR": 18.7182
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.95512,
+        "SIR": 18.6118,
+        "SAR": 7.10745,
+        "ISR": 11.2209
+      },
+      "instrumental": {
+        "SDR": 15.1803,
+        "SIR": 20.1527,
+        "SAR": 18.0093,
+        "ISR": 21.0236
+      }
+    }
   },
   "12_SP-UVR-3B-44100.pth": {
     "model_name": "VR Arch Single Model v5: 12_SP-UVR-3B-44100",
@@ -2276,15 +2787,46 @@
             "SAR": 10.1294,
             "ISR": 14.3904
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.2341,
             "SIR": 20.0053,
             "SAR": 17.2023,
             "ISR": 28.5095
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.02814,
+            "SIR": 13.8688,
+            "SAR": 3.86639,
+            "ISR": 7.45564
+          },
+          "instrumental": {
+            "SDR": 15.0726,
+            "SIR": 18.9793,
+            "SAR": 19.1598,
+            "ISR": 18.6167
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.86786,
+        "SIR": 18.6683,
+        "SAR": 6.99789,
+        "ISR": 10.923
+      },
+      "instrumental": {
+        "SDR": 15.1533,
+        "SIR": 19.4923,
+        "SAR": 18.181,
+        "ISR": 23.5631
+      }
+    }
   },
   "13_SP-UVR-4B-44100-1.pth": {
     "model_name": "VR Arch Single Model v5: 13_SP-UVR-4B-44100-1",
@@ -2298,15 +2840,46 @@
             "SAR": 9.95108,
             "ISR": 14.1401
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.313,
             "SIR": 19.913,
             "SAR": 17.181,
             "ISR": 29.6411
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.41826,
+            "SIR": 14.6844,
+            "SAR": 4.2865,
+            "ISR": 8.28759
+          },
+          "instrumental": {
+            "SDR": 14.8749,
+            "SIR": 19.2658,
+            "SAR": 18.7497,
+            "ISR": 18.731
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.01492,
+        "SIR": 19.3635,
+        "SAR": 7.11879,
+        "ISR": 11.2138
+      },
+      "instrumental": {
+        "SDR": 15.0939,
+        "SIR": 19.5894,
+        "SAR": 17.9654,
+        "ISR": 24.1861
+      }
+    }
   },
   "14_SP-UVR-4B-44100-2.pth": {
     "model_name": "VR Arch Single Model v5: 14_SP-UVR-4B-44100-2",
@@ -2320,15 +2893,46 @@
             "SAR": 10.0074,
             "ISR": 14.4707
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.3879,
             "SIR": 20.1929,
             "SAR": 17.1843,
             "ISR": 29.2083
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.5248,
+            "SIR": 13.5222,
+            "SAR": 4.46966,
+            "ISR": 8.8485
+          },
+          "instrumental": {
+            "SDR": 14.8167,
+            "SIR": 19.8877,
+            "SAR": 18.6056,
+            "ISR": 18.3775
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 7.10172,
+        "SIR": 18.5437,
+        "SAR": 7.23853,
+        "ISR": 11.6596
+      },
+      "instrumental": {
+        "SDR": 15.1023,
+        "SIR": 20.0403,
+        "SAR": 17.895,
+        "ISR": 23.7929
+      }
+    }
   },
   "15_SP-UVR-MID-44100-1.pth": {
     "model_name": "VR Arch Single Model v5: 15_SP-UVR-MID-44100-1",
@@ -2342,15 +2946,46 @@
             "SAR": 10.1794,
             "ISR": 13.951
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.2945,
             "SIR": 19.4523,
             "SAR": 17.3117,
             "ISR": 29.1805
           }
         }
+      },
+      {
+        "track_name": "A Classic Education - NightOwl",
+        "scores": {
+          "vocals": {
+            "SDR": 4.04636,
+            "SIR": 14.85,
+            "SAR": 3.83909,
+            "ISR": 7.84627
+          },
+          "instrumental": {
+            "SDR": 15.8345,
+            "SIR": 19.119,
+            "SAR": 19.62,
+            "ISR": 19.9563
+          }
+        }
       }
-    ]
+    ],
+    "median_scores": {
+      "vocals": {
+        "SDR": 6.91868,
+        "SIR": 19.5925,
+        "SAR": 7.00924,
+        "ISR": 10.8986
+      },
+      "instrumental": {
+        "SDR": 15.5645,
+        "SIR": 19.2857,
+        "SAR": 18.4658,
+        "ISR": 24.5684
+      }
+    }
   },
   "16_SP-UVR-MID-44100-2.pth": {
     "model_name": "VR Arch Single Model v5: 16_SP-UVR-MID-44100-2",
@@ -2364,7 +2999,7 @@
             "SAR": 10.1456,
             "ISR": 14.0142
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.3468,
             "SIR": 19.6379,
             "SAR": 17.3318,
@@ -2422,7 +3057,7 @@
             "SAR": -0.14961,
             "ISR": 0.25838
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 5.96176,
             "SIR": 5.44499,
             "SAR": 22.8911,
@@ -2444,7 +3079,7 @@
             "SAR": 9.19876,
             "ISR": 13.2267
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.5235,
             "SIR": 18.6889,
             "SAR": 16.3961,
@@ -2466,7 +3101,7 @@
             "SAR": 9.73736,
             "ISR": 13.6806
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.7954,
             "SIR": 19.5061,
             "SAR": 16.5979,
@@ -2488,7 +3123,7 @@
             "SAR": 9.47714,
             "ISR": 15.0702
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.1628,
             "SIR": 20.9989,
             "SAR": 16.2524,
@@ -2510,7 +3145,7 @@
             "SAR": 9.54069,
             "ISR": 13.2684
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.8543,
             "SIR": 18.9902,
             "SAR": 16.8714,
@@ -2536,7 +3171,7 @@
             "SAR": 11.6046,
             "ISR": 16.0831
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.7201,
             "SIR": 27.6394,
             "SAR": 17.9174,
@@ -2558,7 +3193,7 @@
             "SAR": 11.7597,
             "ISR": 16.2739
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.5581,
             "SIR": 28.2464,
             "SAR": 18.0253,
@@ -2580,7 +3215,7 @@
             "SAR": 11.7719,
             "ISR": 16.4426
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.6439,
             "SIR": 28.5379,
             "SAR": 18.0557,
@@ -2602,7 +3237,7 @@
             "SAR": 11.5791,
             "ISR": 16.4573
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.299,
             "SIR": 28.6137,
             "SAR": 17.7593,
@@ -2624,7 +3259,7 @@
             "SAR": 13.0257,
             "ISR": 16.0096
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.5944,
             "SIR": 27.503,
             "SAR": 19.6799,
@@ -2646,7 +3281,7 @@
             "SAR": 11.2457,
             "ISR": 16.1646
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.1549,
             "SIR": 27.9234,
             "SAR": 17.4862,
@@ -2668,7 +3303,7 @@
             "SAR": 12.1804,
             "ISR": 15.7737
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.0006,
             "SIR": 26.5245,
             "SAR": 18.7919,
@@ -2690,7 +3325,7 @@
             "SAR": 11.9763,
             "ISR": 15.2049
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.9336,
             "SIR": 25.8227,
             "SAR": 18.5257,
@@ -2712,7 +3347,7 @@
             "SAR": 12.0279,
             "ISR": 15.6543
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.9171,
             "SIR": 26.4054,
             "SAR": 18.4532,
@@ -2734,7 +3369,7 @@
             "SAR": 12.1032,
             "ISR": 16.389
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.6734,
             "SIR": 28.4454,
             "SAR": 18.5376,
@@ -2756,7 +3391,7 @@
             "SAR": 12.0741,
             "ISR": 16.3525
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.9117,
             "SIR": 28.3142,
             "SAR": 18.5092,
@@ -2778,7 +3413,7 @@
             "SAR": 12.2344,
             "ISR": 16.2185
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.7759,
             "SIR": 28.2301,
             "SAR": 18.5244,
@@ -2800,7 +3435,7 @@
             "SAR": 11.2309,
             "ISR": 13.3676
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.95,
             "SIR": 22.9958,
             "SAR": 18.4961,
@@ -2822,7 +3457,7 @@
             "SAR": 10.2868,
             "ISR": 14.4427
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.1983,
             "SIR": 24.6327,
             "SAR": 17.3137,
@@ -2844,7 +3479,7 @@
             "SAR": 11.8461,
             "ISR": 14.8779
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.894,
             "SIR": 25.3042,
             "SAR": 18.4495,
@@ -2866,7 +3501,7 @@
             "SAR": 13.182,
             "ISR": 16.0212
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.6065,
             "SIR": 27.6932,
             "SAR": 19.6089,
@@ -2888,7 +3523,7 @@
             "SAR": 12.9673,
             "ISR": 16.0053
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.4672,
             "SIR": 27.5393,
             "SAR": 19.5319,
@@ -2910,7 +3545,7 @@
             "SAR": 13.1356,
             "ISR": 16.2254
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.5885,
             "SIR": 28.0783,
             "SAR": 19.7163,
@@ -2932,7 +3567,7 @@
             "SAR": 12.0459,
             "ISR": 16.2864
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.7901,
             "SIR": 28.1077,
             "SAR": 18.4411,
@@ -2966,7 +3601,7 @@
             "SAR": 12.0226,
             "ISR": 13.9254
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.1396,
             "SIR": 23.6448,
             "SAR": 19.0724,
@@ -3002,7 +3637,7 @@
             "SAR": 11.7906,
             "ISR": 15.0603
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.9372,
             "SIR": 25.6451,
             "SAR": 18.4079,
@@ -3038,7 +3673,7 @@
             "SAR": 12.919,
             "ISR": 16.6519
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.4912,
             "SIR": 28.3176,
             "SAR": 19.112,
@@ -3060,7 +3695,7 @@
             "SAR": 12.9878,
             "ISR": 6.2915
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 9.03462,
             "SIR": 9.19492,
             "SAR": 15.3302,
@@ -3082,7 +3717,7 @@
             "SAR": 13.0783,
             "ISR": 18.2171
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.3575,
             "SIR": 29.2259,
             "SAR": 19.2459,
@@ -3104,7 +3739,7 @@
             "SAR": 13.083,
             "ISR": 16.1862
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.6029,
             "SIR": 28.0326,
             "SAR": 19.5602,
@@ -3126,7 +3761,7 @@
             "SAR": 13.2416,
             "ISR": 15.9161
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.4981,
             "SIR": 27.5529,
             "SAR": 19.5714,
@@ -3148,7 +3783,7 @@
             "SAR": 11.335,
             "ISR": 15.3117
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.9986,
             "SIR": 25.9346,
             "SAR": 17.6734,
@@ -3170,7 +3805,7 @@
             "SAR": 11.721,
             "ISR": 15.5642
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.3123,
             "SIR": 26.4022,
             "SAR": 17.7831,
@@ -3192,7 +3827,7 @@
             "SAR": 12.2004,
             "ISR": 15.9915
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 14.5594,
             "SIR": 27.1713,
             "SAR": 18.1641,
@@ -3214,7 +3849,7 @@
             "SAR": 11.5208,
             "ISR": 16.0342
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 15.3967,
             "SIR": 27.4994,
             "SAR": 17.8466,
@@ -3372,7 +4007,7 @@
             "SAR": 13.4577,
             "ISR": 16.095
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.8081,
             "SIR": 27.6401,
             "SAR": 19.9845,
@@ -3394,7 +4029,7 @@
             "SAR": 12.1722,
             "ISR": 14.8268
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.3295,
             "SIR": 24.8897,
             "SAR": 18.9426,
@@ -3416,7 +4051,7 @@
             "SAR": 13.3726,
             "ISR": 16.0716
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.9593,
             "SIR": 27.5912,
             "SAR": 19.9074,
@@ -3438,7 +4073,7 @@
             "SAR": 14.0441,
             "ISR": 17.2849
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 17.2905,
             "SIR": 30.0163,
             "SAR": 20.6951,
@@ -3460,7 +4095,7 @@
             "SAR": 14.0864,
             "ISR": 17.2478
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 17.3035,
             "SIR": 30.0666,
             "SAR": 20.6723,
@@ -3488,7 +4123,7 @@
             "SAR": 13.0711,
             "ISR": 16.2842
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.4826,
             "SIR": 27.7054,
             "SAR": 19.3585,
@@ -3514,7 +4149,7 @@
             "SAR": 13.354,
             "ISR": 14.825
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 17.1356,
             "SIR": 24.909,
             "SAR": 20.1133,
@@ -3562,7 +4197,7 @@
             "SAR": 12.7786,
             "ISR": 14.9145
           },
-          "accompaniment": {
+          "instrumental": {
             "SDR": 16.631,
             "SIR": 25.3515,
             "SAR": 19.4912,

--- a/audio_separator/separator/common_separator.py
+++ b/audio_separator/separator/common_separator.py
@@ -377,7 +377,10 @@ class CommonSeparator:
         """
         Gets the output path for a stem based on the stem name and custom output names.
         """
-        if custom_output_names and stem_name in custom_output_names:
-            return os.path.join(f"{custom_output_names[stem_name]}.{self.output_format.lower()}")
-        else:
-            return os.path.join(f"{self.audio_file_base}_({stem_name})_{self.model_name}.{self.output_format.lower()}")
+        # Convert custom_output_names keys to lowercase for case-insensitive comparison
+        if custom_output_names:
+            custom_output_names_lower = {k.lower(): v for k, v in custom_output_names.items()}
+            if stem_name.lower() in custom_output_names_lower:
+                return os.path.join(f"{custom_output_names_lower[stem_name.lower()]}.{self.output_format.lower()}")
+
+        return os.path.join(f"{self.audio_file_base}_({stem_name})_{self.model_name}.{self.output_format.lower()}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "audio-separator"
-version = "0.27.0"
+version = "0.27.1"
 description = "Easy to use audio stem separation, using various models from UVR trained primarily by @Anjok07"
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/model-metrics/test-all-models.py
+++ b/tests/model-metrics/test-all-models.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+import os
+import museval
+import numpy as np
+import soundfile as sf
+from audio_separator.separator import Separator
+from pathlib import Path
+import json
+import logging
+import musdb
+from decimal import Decimal
+import pandas as pd
+
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+MUSDB_PATH = "tests/model-metrics/datasets/musdb18hq"
+RESULTS_PATH = "tests/model-metrics/results"
+
+
+def evaluate_track(track_name, track_path, test_model, mus_db):
+    """Evaluate a single track using a specific model"""
+    logger.info(f"Evaluating track: {track_name} with model: {test_model}")
+
+    # Set output directory for this separation
+    output_dir = os.path.join(RESULTS_PATH, test_model, track_name)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Check if separated files already exist
+    vocals_path = os.path.join(output_dir, "vocals.wav")
+    instrumental_path = os.path.join(output_dir, "instrumental.wav")
+
+    if not (os.path.exists(vocals_path) and os.path.exists(instrumental_path)):
+        logger.info("Performing separation...")
+        separator = Separator(output_dir=output_dir)
+        separator.load_model(model_filename=test_model)
+        separator.separate(os.path.join(track_path, "mixture.wav"), custom_output_names={"Vocals": "vocals", "Instrumental": "instrumental"})
+
+    # Get track from MUSDB
+    track = next((t for t in mus_db if t.name == track_name), None)
+    if track is None:
+        raise ValueError(f"Track {track_name} not found in MUSDB18")
+
+    # Load estimated stems
+    estimates = {}
+    for stem_name in ["vocals", "accompaniment"]:
+        stem_path = vocals_path if stem_name == "vocals" else instrumental_path
+        audio, _ = sf.read(stem_path)
+        if len(audio.shape) == 1:
+            audio = np.expand_dims(audio, axis=1)
+        estimates[stem_name] = audio
+
+    # Evaluate using museval
+    scores = museval.eval_mus_track(track, estimates, output_dir=output_dir, mode="v4")
+
+    # Move and rename the results file
+    test_results = os.path.join(output_dir, "test", f"{track_name}.json")
+    new_results = os.path.join(output_dir, "museval-results.json")
+    if os.path.exists(test_results):
+        os.rename(test_results, new_results)
+        os.rmdir(os.path.join(output_dir, "test"))
+
+    # Calculate aggregate scores
+    results_store = museval.EvalStore()
+    results_store.add_track(scores.df)
+    methods = museval.MethodStore()
+    methods.add_evalstore(results_store, name=test_model)
+    agg_scores = methods.agg_frames_tracks_scores()
+
+    # Log results
+    logger.info(
+        "Vocals (SDR, SIR, SAR, ISR): %.2f, %.2f, %.2f, %.2f",
+        agg_scores.loc[(test_model, "vocals", "SDR")],
+        agg_scores.loc[(test_model, "vocals", "SIR")],
+        agg_scores.loc[(test_model, "vocals", "SAR")],
+        agg_scores.loc[(test_model, "vocals", "ISR")],
+    )
+
+    logger.info(
+        "Accompaniment (SDR, SIR, SAR, ISR): %.2f, %.2f, %.2f, %.2f",
+        agg_scores.loc[(test_model, "accompaniment", "SDR")],
+        agg_scores.loc[(test_model, "accompaniment", "SIR")],
+        agg_scores.loc[(test_model, "accompaniment", "SAR")],
+        agg_scores.loc[(test_model, "accompaniment", "ISR")],
+    )
+
+
+def convert_decimal_to_float(obj):
+    """Recursively converts Decimal objects to floats in a nested structure."""
+    if isinstance(obj, Decimal):
+        return float(obj)
+    elif isinstance(obj, dict):
+        return {k: convert_decimal_to_float(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [convert_decimal_to_float(x) for x in obj]
+    return obj
+
+
+def main():
+    logger.info("Starting model evaluation script...")
+
+    # Create results directory
+    os.makedirs(RESULTS_PATH, exist_ok=True)
+
+    # Initialize MUSDB once at the start
+    logger.info("Initializing MUSDB database...")
+    mus = musdb.DB(root=MUSDB_PATH, is_wav=True)
+
+    # Get list of all available models
+    logger.info("Getting list of available models...")
+    separator = Separator()
+    models_by_type = separator.list_supported_model_files()
+
+    # Just get the first model for testing
+    test_model = None
+    for model_type, models in models_by_type.items():
+        for model_name, model_info in models.items():
+            if isinstance(model_info, str):
+                test_model = model_info
+                break
+            elif isinstance(model_info, dict):
+                for file_name in model_info.keys():
+                    if file_name.endswith((".onnx", ".pth", ".ckpt")):
+                        test_model = file_name
+                        break
+        if test_model:
+            break
+
+    logger.info(f"Selected model for testing: {test_model}")
+
+    # Get first track from MUSDB18
+    logger.info("Looking for first track in MUSDB18 dataset...")
+    first_track = next(Path(MUSDB_PATH).glob("**/mixture.wav"))
+    track_path = first_track.parent
+    track_name = track_path.name
+    logger.info(f"Found track: {track_name} at path: {track_path}")
+
+    try:
+        logger.info("Starting track evaluation...")
+        evaluate_track(track_name, track_path, test_model, mus)
+        logger.info("Completed evaluation")
+
+    except Exception as e:
+        logger.error(f"Error during evaluation: {str(e)}")
+        logger.error("Error details:", exc_info=True)
+        return 1
+
+    # Clean up any test directories that might have been created
+    test_dir = os.path.join(RESULTS_PATH, test_model, track_name, "test")
+    if os.path.exists(test_dir):
+        import shutil
+
+        shutil.rmtree(test_dir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tests/model-metrics/test-all-models.py
+++ b/tests/model-metrics/test-all-models.py
@@ -28,39 +28,48 @@ def evaluate_track(track_name, track_path, test_model, mus_db):
     output_dir = os.path.join(RESULTS_PATH, test_model, track_name)
     os.makedirs(output_dir, exist_ok=True)
 
-    # Check if separated files already exist
-    vocals_path = os.path.join(output_dir, "vocals.wav")
-    instrumental_path = os.path.join(output_dir, "instrumental.wav")
+    # Check if evaluation results already exist
+    results_file = os.path.join(output_dir, "museval-results.json")
+    if os.path.exists(results_file):
+        logger.info("Found existing evaluation results, loading from file...")
+        with open(results_file) as f:
+            json_data = json.load(f)
+        scores = museval.TrackStore(track_name)
+        scores.scores = json_data
+    else:
+        # Check if separated files already exist
+        vocals_path = os.path.join(output_dir, "vocals.wav")
+        instrumental_path = os.path.join(output_dir, "instrumental.wav")
 
-    if not (os.path.exists(vocals_path) and os.path.exists(instrumental_path)):
-        logger.info("Performing separation...")
-        separator = Separator(output_dir=output_dir)
-        separator.load_model(model_filename=test_model)
-        separator.separate(os.path.join(track_path, "mixture.wav"), custom_output_names={"Vocals": "vocals", "Instrumental": "instrumental"})
+        if not (os.path.exists(vocals_path) and os.path.exists(instrumental_path)):
+            logger.info("Performing separation...")
+            separator = Separator(output_dir=output_dir)
+            separator.load_model(model_filename=test_model)
+            separator.separate(os.path.join(track_path, "mixture.wav"), custom_output_names={"Vocals": "vocals", "Instrumental": "instrumental"})
 
-    # Get track from MUSDB
-    track = next((t for t in mus_db if t.name == track_name), None)
-    if track is None:
-        raise ValueError(f"Track {track_name} not found in MUSDB18")
+        # Get track from MUSDB
+        track = next((t for t in mus_db if t.name == track_name), None)
+        if track is None:
+            raise ValueError(f"Track {track_name} not found in MUSDB18")
 
-    # Load estimated stems
-    estimates = {}
-    for stem_name in ["vocals", "accompaniment"]:
-        stem_path = vocals_path if stem_name == "vocals" else instrumental_path
-        audio, _ = sf.read(stem_path)
-        if len(audio.shape) == 1:
-            audio = np.expand_dims(audio, axis=1)
-        estimates[stem_name] = audio
+        # Load estimated stems
+        estimates = {}
+        for stem_name in ["vocals", "accompaniment"]:
+            stem_path = vocals_path if stem_name == "vocals" else instrumental_path
+            audio, _ = sf.read(stem_path)
+            if len(audio.shape) == 1:
+                audio = np.expand_dims(audio, axis=1)
+            estimates[stem_name] = audio
 
-    # Evaluate using museval
-    scores = museval.eval_mus_track(track, estimates, output_dir=output_dir, mode="v4")
+        # Evaluate using museval
+        logger.info("Performing evaluation...")
+        scores = museval.eval_mus_track(track, estimates, output_dir=output_dir, mode="v4")
 
-    # Move and rename the results file
-    test_results = os.path.join(output_dir, "test", f"{track_name}.json")
-    new_results = os.path.join(output_dir, "museval-results.json")
-    if os.path.exists(test_results):
-        os.rename(test_results, new_results)
-        os.rmdir(os.path.join(output_dir, "test"))
+        # Move and rename the results file
+        test_results = os.path.join(output_dir, "test", f"{track_name}.json")
+        if os.path.exists(test_results):
+            os.rename(test_results, results_file)
+            os.rmdir(os.path.join(output_dir, "test"))
 
     # Calculate aggregate scores
     results_store = museval.EvalStore()


### PR DESCRIPTION
Begin adding evaluation scores for all models, initially MUSEDB18. 

Fixed UVR-De-Reverb-aufr33-jarredou.pth model by adding new model-data dict appended to the UVR one