### PR TITLE
MDX23C DrumSep model

### DIFF
--- a/audio_separator/models.json
+++ b/audio_separator/models.json
@@ -4,7 +4,8 @@
     },
     "mdx_download_list": {},
     "mdx23c_download_list": {
-        "MDX23C Model: MDX23C De-Reverb by aufr33-jarredou": {"MDX23C-De-Reverb-aufr33-jarredou.ckpt":"config_dereverb_mdx23c.yaml"}
+        "MDX23C Model: MDX23C De-Reverb by aufr33-jarredou": {"MDX23C-De-Reverb-aufr33-jarredou.ckpt":"config_dereverb_mdx23c.yaml"},
+        "MDX23C Model: MDX23C DrumSep by aufr33-jarredou": {"MDX23C-DrumSep-aufr33-jarredou.ckpt":"config_drumsep_mdx23c.yaml"}
     },
     "roformer_download_list": {
         "Roformer Model: Mel-Roformer-Karaoke-Aufr33-Viperx": {


### PR DESCRIPTION
### **MDX23C DrumSep by aufr33 & jarredou**

Checkpoint Link: [ckpt](https://github.com/Eddycrack864/models_test/releases/download/model-configs/MDX23C-DrumSep-aufr33-jarredou.ckpt)
Config Link: [config](https://github.com/Eddycrack864/models_test/releases/download/model-configs/config_drumsep_mdx23c.yaml)

SDR: 10.8059

This is a 6 stem model: kick, snare, toms, hh (hi hats), ride, crash.

### Note:

This model needs a workaround as currently the MDX23C separator only supports 2 stems, so if you use this model you will only get 2 stems instead of 6 stems.
