### PR TITLE
New Roformer Models

### DIFF
--- a/audio_separator/models.json
+++ b/audio_separator/models.json
@@ -82,6 +82,27 @@
         },
         "Roformer Model: MelBand Roformer | Bleed Suppressor V1 by unwa-97chris": {
             "mel_band_roformer_bleed_suppressor_v1.ckpt": "config_mel_band_roformer_bleed_suppressor_v1.yaml"
+        },
+        "Roformer Model: BS Roformer | Inst EXP Value Residual by unwa": {
+            "BS_Inst_EXP_VRL.ckpt": "BS_Inst_EXP_VRL.yaml"
+        },
+        "Roformer Model: MelBand Roformer Kim | FT2 by unwa": {
+            "kimmel_unwa_ft2.ckpt": "config_mel_band_roformer_kim_ft_unwa.yaml"
+        },
+        "Roformer Model: MelBand Roformer | De-Reverb Big by Sucial": {
+            "de_big_reverb_mbr_ep_362.ckpt": "config_dereverb_echo_mbr_v2.yaml"
+        },
+        "Roformer Model: MelBand Roformer | De-Reverb Super Big by Sucial": {
+            "de_super_big_reverb_mbr_ep_346.ckpt": "config_dereverb_echo_mbr_v2.yaml"
+        },
+        "Roformer Model: MelBand Roformer | De-Reverb-Echo Fused by Sucial": {
+            "dereverb_echo_mbr_fused_0.5_v2_0.25_big_0.25_super.ckpt": "config_dereverb_echo_mbr_v2.yaml"
+        },
+        "Roformer Model: MelBand Roformer | Vocals by Becruily": {
+            "mel_band_roformer_vocals_becruily.ckpt": "config_vocals_becruily.yaml"
+        },
+        "Roformer Model: MelBand Roformer | Instrumental by Becruily": {
+            "mel_band_roformer_instrumental_becruily.ckpt": "config_instrumental_becruily.yaml"
         }
     }
 }


### PR DESCRIPTION
I proposed these models in this issue: [https://github.com/nomadkaraoke/python-audio-separator/issues/173](https://github.com/nomadkaraoke/python-audio-separator/issues/173)

> *"Recently, the files [bs_roformer.py](https://github.com/lucidrains/BS-RoFormer/blob/main/bs_roformer/bs_roformer.py) and [mel_band_roformer.py](https://github.com/lucidrains/BS-RoFormer/blob/main/bs_roformer/mel_band_roformer.py) have been updated. It would be beneficial to update them here as well for the new models that work specifically with this update."*

## BS Roformer | Inst EXP Value Residual by unwa

*For this model, the files **[bs_roformer.py](https://github.com/lucidrains/BS-RoFormer/blob/main/bs_roformer/bs_roformer.py)** and **[mel_band_roformer.py](https://github.com/lucidrains/BS-RoFormer/blob/main/bs_roformer/mel_band_roformer.py)** need to be updated.*

Checkpoint Link: [ckpt](https://huggingface.co/pcunwa/BS-Roformer-Inst-EXP-Value-Residual/resolve/main/BS_Inst_EXP_VRL.ckpt?download=true)
Config Link: [config](https://huggingface.co/pcunwa/BS-Roformer-Inst-EXP-Value-Residual/resolve/main/BS_Inst_EXP_VRL.yaml?download=true)

## MelBand Roformer Kim | FT2 by unwa

Checkpoint Link: [ckpt](https://huggingface.co/pcunwa/Kim-Mel-Band-Roformer-FT/resolve/main/kimmel_unwa_ft2.ckpt?download=true)
Config Link: [config](https://huggingface.co/pcunwa/Kim-Mel-Band-Roformer-FT/resolve/main/config_kimmel_unwa_ft.yaml?download=true)
*Or the existing one*: **`config_mel_band_roformer_kim_ft_unwa.yaml`**

## MelBand Roformer | De-Reverb Big by Sucial

Checkpoint Link: [ckpt](https://huggingface.co/Sucial/Dereverb-Echo_Mel_Band_Roformer/resolve/main/de_big_reverb_mbr_ep_362.ckpt?download=true)
Config Link: [config](https://huggingface.co/Sucial/Dereverb-Echo_Mel_Band_Roformer/resolve/main/config_dereverb_echo_mbr_v2.yaml?download=true)

## MelBand Roformer | De-Reverb Super Big by Sucial

Checkpoint Link: [ckpt](https://huggingface.co/Sucial/Dereverb-Echo_Mel_Band_Roformer/resolve/main/de_super_big_reverb_mbr_ep_346.ckpt?download=true)
Config Link: [config](https://huggingface.co/Sucial/Dereverb-Echo_Mel_Band_Roformer/resolve/main/config_dereverb_echo_mbr_v2.yaml?download=true)

## MelBand Roformer | De-Reverb-Echo Fused by Sucial

Checkpoint Link: [ckpt](https://huggingface.co/Sucial/Dereverb-Echo_Mel_Band_Roformer/resolve/main/dereverb_echo_mbr_fused_0.5_v2_0.25_big_0.25_super.ckpt?download=true)
Config Link: [config](https://huggingface.co/Sucial/Dereverb-Echo_Mel_Band_Roformer/resolve/main/config_dereverb_echo_mbr_v2.yaml?download=true)

## MelBand Roformer | Vocals by Becruily

Checkpoint Link: [ckpt](https://huggingface.co/becruily/mel-band-roformer-vocals/resolve/main/mel_band_roformer_vocals_becruily.ckpt?download=true)
Config Link: [config](https://huggingface.co/becruily/mel-band-roformer-vocals/resolve/main/config_vocals_becruily.yaml?download=true)

## MelBand Roformer | Instrumental by Becruily

Checkpoint Link: [ckpt](https://huggingface.co/becruily/mel-band-roformer-instrumental/resolve/main/mel_band_roformer_instrumental_becruily.ckpt?download=true)
Config Link: [config](https://huggingface.co/becruily/mel-band-roformer-instrumental/resolve/main/config_instrumental_becruily.yaml?download=true)

---

Unfortunately, I don't know if these models work correctly, as I didn't have time to check. It's possible that some models may require updating their config files, or maybe they won't need it :)

I was unable to update the files bs_roformer.py and mel_band_roformer.py myself, so I will leave that task to you. 🤷‍♂️