### PR TITLE
Cleaning filenames from forbidden characters

### DIFF
--- a/audio_separator/separator/common_separator.py
+++ b/audio_separator/separator/common_separator.py
@@ -373,6 +373,15 @@ class CommonSeparator:
         self.primary_stem_output_path = None
         self.secondary_stem_output_path = None
 
+    def sanitize_filename(self, filename):
+        """
+        Cleans the filename by replacing invalid characters with underscores.
+        """
+        sanitized = re.sub(r'[<>:"/\\|?*]', '_', filename)
+        sanitized = re.sub(r'_+', '_', sanitized)
+        sanitized = sanitized.strip('_. ')
+        return sanitized
+
     def get_stem_output_path(self, stem_name, custom_output_names):
         """
         Gets the output path for a stem based on the stem name and custom output names.
@@ -380,7 +389,14 @@ class CommonSeparator:
         # Convert custom_output_names keys to lowercase for case-insensitive comparison
         if custom_output_names:
             custom_output_names_lower = {k.lower(): v for k, v in custom_output_names.items()}
-            if stem_name.lower() in custom_output_names_lower:
-                return os.path.join(f"{custom_output_names_lower[stem_name.lower()]}.{self.output_format.lower()}")
+            stem_name_lower = stem_name.lower()
+            if stem_name_lower in custom_output_names_lower:
+                sanitized_custom_name = self.sanitize_filename(custom_output_names_lower[stem_name_lower])
+                return os.path.join(f"{sanitized_custom_name}.{self.output_format.lower()}")
 
-        return os.path.join(f"{self.audio_file_base}_({stem_name})_{self.model_name}.{self.output_format.lower()}")
+        sanitized_audio_base = self.sanitize_filename(self.audio_file_base)
+        sanitized_stem_name = self.sanitize_filename(stem_name)
+        sanitized_model_name = self.sanitize_filename(self.model_name) 
+
+        filename = f"{sanitized_audio_base}_({sanitized_stem_name})_{sanitized_model_name}.{self.output_format.lower()}"
+        return os.path.join(filename)


### PR DESCRIPTION
Do you think it's worth adding a similar file name cleaning function?
Some of my acquaintances have encountered the following error on Windows:
```
Error exporting audio file: [Errno 22] Invalid argument: 'output/UVR_output\\саи\\саи_(Vocals)_MelBand Roformer Kim | Vocals v3 by Aname.wav'
```
However, when I run the audio separator on my PC with the same system, I don't encounter any such errors, which is strange. 🤷‍♂️

---

### Full log
```
2025-04-24 23:22:33 | ERROR | audio_separator.separator.separator | Error exporting audio file: [Errno 22] Invalid argument: 'output/UVR_output\\саи\\саи_(Vocals)_MelBand Roformer Kim | Vocals v3 by Aname.wav'
Separation complete!
Results: саи_(Other)_MelBand Roformer Kim | Vocals v3 by Aname.wav, саи_(Vocals)_MelBand Roformer Kim | Vocals v3 by Aname.wav
Traceback (most recent call last):
  File "D:\python3104\lib\site-packages\gradio\queueing.py", line 625, in process_events
    response = await route_utils.call_process_api(
  File "D:\python3104\lib\site-packages\gradio\route_utils.py", line 322, in call_process_api
    output = await app.get_blocks().process_api(
  File "D:\python3104\lib\site-packages\gradio\blocks.py", line 2106, in process_api
    data = await self.postprocess_data(block_fn, result["prediction"], state)
  File "D:\python3104\lib\site-packages\gradio\blocks.py", line 1914, in postprocess_data
    outputs_cached = await processing_utils.async_move_files_to_cache(
  File "D:\python3104\lib\site-packages\gradio\processing_utils.py", line 648, in async_move_files_to_cache
    return await client_utils.async_traverse(
  File "D:\python3104\lib\site-packages\gradio_client\utils.py", line 1124, in async_traverse
    return await func(json_obj)
  File "D:\python3104\lib\site-packages\gradio\processing_utils.py", line 621, in _move_to_cache
    temp_file_path = await block.async_move_resource_to_block_cache(
  File "D:\python3104\lib\site-packages\gradio\blocks.py", line 313, in async_move_resource_to_block_cache
    temp_file_path = processing_utils.save_file_to_cache(
  File "D:\python3104\lib\site-packages\gradio\processing_utils.py", line 277, in save_file_to_cache
    temp_dir = hash_file(file_path)
  File "D:\python3104\lib\site-packages\gradio\processing_utils.py", line 206, in hash_file
    with open(file_path, "rb") as f:
OSError: [Errno 22] Invalid argument: 'D:\\PolGen-1.3.0-beta.5_Win\\PolGen-1.3.0\\output\\UVR_output\\саи\\саи_(Other)_MelBand Roformer Kim | Vocals v3 by Aname.wav'
```