### PR TITLE
feat: Auto-enable override_model_segment_size for short audio in MDXC separator

### DIFF
--- a/audio_separator/separator/architectures/mdxc_separator.py
+++ b/audio_separator/separator/architectures/mdxc_separator.py
@@ -138,6 +138,15 @@ class MDXCSeparator(CommonSeparator):
         self.logger.debug(f"Preparing mix for input audio file {self.audio_file_path}...")
         mix = self.prepare_mix(self.audio_file_path)
 
+        # Check if audio is shorter than threshold
+        audio_duration_seconds = mix.shape[1] / self.sample_rate
+        if audio_duration_seconds < 10.0:
+            # Only change and warn if it wasn't already set by the user
+            if not self.override_model_segment_size:
+                self.override_model_segment_size = True
+                self.logger.warning(f"Audio duration ({audio_duration_seconds:.2f}s) is less than 10 seconds.")
+                self.logger.warning("Automatically enabling override_model_segment_size for better processing of short audio.")
+
         self.logger.debug("Normalizing mix before demixing...")
         mix = spec_utils.normalize(wave=mix, max_peak=self.normalization_threshold, min_peak=self.amplification_threshold)
 


### PR DESCRIPTION
## Description
This PR introduces automatic detection and handling of short audio files (< 10 seconds) in the MDXC separator to prevent potential issues (as here: https://github.com/nomadkaraoke/python-audio-separator/issues/189).

The separator now automatically:
- Detects when input audio is shorter than 10 seconds
- Enables `override_model_segment_size` parameter automatically if not already set by user
- Logs appropriate warnings to inform the user about the automatic adjustment

## Example Log Output
```
2025-09-22 17:41:42,527 - WARNING - mdxc_separator - Audio duration (3.72s) is less than 10 seconds.
2025-09-22 17:41:42,527 - WARNING - mdxc_separator - Automatically enabling override_model_segment_size for better processing of short audio.
```

---

- [x] Tested with audio files < 10 seconds
- [x] Tested with audio files > 10 seconds  
- [x] Verified warning messages appear correctly