### PR TITLE
New models until 10-19-2025

### DIFF
--- a/audio_separator/models.json
+++ b/audio_separator/models.json
@@ -27,6 +27,12 @@
         "Roformer Model: MelBand Roformer | Karaoke by becruily": {
             "mel_band_roformer_karaoke_becruily.ckpt": "config_mel_band_roformer_karaoke_becruily.yaml"
         },
+        "Roformer Model: BS Roformer | Karaoke by frazer-becruily": {
+            "bs_roformer_karaoke_frazer_becruily.ckpt": "config_bs_roformer_karaoke_frazer_becruily.yaml"
+        },
+        "Roformer Model: BS Roformer | Karaoke by anvuew": {
+            "bs_roformer_karaoke_anvuew.ckpt": "config_bs_roformer_karaoke_anvuew.yaml"
+        },
         "Roformer Model: Mel-Roformer-Denoise-Aufr33": {
             "denoise_mel_band_roformer_aufr33_sdr_27.9959.ckpt": "denoise_mel_band_roformer_aufr33_sdr_27.9959_config.yaml"
         },
@@ -111,6 +117,9 @@
         "Roformer Model: MelBand Roformer | Vocals FV6 by Gabox": {
             "mel_band_roformer_vocals_fv6_gabox.ckpt": "config_mel_band_roformer_vocals_gabox.yaml"
         },
+        "Roformer Model: MelBand Roformer | Vocals FV7b by Gabox": {
+            "mel_band_roformer_vocals_fv7b_gabox.ckpt": "config_mel_band_roformer_vocals_gabox.yaml"
+        },
         "Roformer Model: MelBand Roformer | Instrumental by Gabox": {
             "mel_band_roformer_instrumental_gabox.ckpt": "config_mel_band_roformer_instrumental_gabox.yaml"
         },
@@ -137,6 +146,9 @@
         },
         "Roformer Model: MelBand Roformer | Instrumental Fullness V3 by Gabox": {
             "mel_band_roformer_instrumental_fullness_v3_gabox.ckpt": "config_mel_band_roformer_instrumental_gabox.yaml"
+        },
+        "Roformer Model: MelBand Roformer | Instrumental Fullness V4 by Gabox": {
+            "mel_band_roformer_instrumental_fullness_v4_gabox.ckpt": "config_mel_band_roformer_instrumental_gabox.yaml"
         },
         "Roformer Model: MelBand Roformer | Instrumental Fullness Noisy V4 by Gabox": {
             "mel_band_roformer_instrumental_fullness_noise_v4_gabox.ckpt": "config_mel_band_roformer_instrumental_gabox.yaml"
@@ -170,6 +182,9 @@
         },
         "Roformer Model: MelBand Roformer | Instrumental FV8 by Gabox": {
             "mel_band_roformer_instrumental_fv8_gabox.ckpt": "config_mel_band_roformer_instrumental_gabox.yaml"
+        },
+        "Roformer Model: MelBand Roformer | Instrumental FV8b by Gabox": {
+            "mel_band_roformer_instrumental_fv8b_gabox.ckpt": "config_mel_band_roformer_instrumental_gabox.yaml"
         },
         "Roformer Model: MelBand Roformer | Instrumental FVX by Gabox": {
             "mel_band_roformer_instrumental_fvx_gabox.ckpt": "config_mel_band_roformer_instrumental_gabox.yaml"
@@ -245,6 +260,9 @@
         },
         "Roformer Model: BS Roformer | Instrumental Resurrection by unwa": {
             "bs_roformer_instrumental_resurrection_unwa.ckpt": "config_bs_roformer_instrumental_resurrection_unwa.yaml"
+        },
+        "Roformer Model: BS Roformer | Instrumental ResurrectioN by Gabox": {
+            "bs_roformer_instrumental_resurrection_gabox.ckpt": "config_bs_roformer_instrumental_resurrection_unwa.yaml"
         },
         "Roformer Model: BS Roformer SW by jarredou": {
             "BS-Roformer-SW.ckpt": "BS-Roformer-SW.yaml"


### PR DESCRIPTION
## Models:
### **BS Roformer | Karaoke by frazer-becruily**
### **BS Roformer | Karaoke by anvuew**
### **MelBand Roformer | Vocals FV7b by Gabox**
### **MelBand Roformer | Instrumental Fullness V4 by Gabox**
### **MelBand Roformer | Instrumental FV8b by Gabox**
### **BS Roformer | Instrumental ResurrectioN by Gabox**

Models already tested on my end and the files (.ckpt and .yaml) are already uploaded to the repo

---
I tried adding the models:
**BS Roformer | De-Reverb Room by anvuew**, but I faced this problem after a mask_estimator mismatch:
```
2025-10-19 17:04:32,762 - WARNING - mdxc_separator - Audio duration (5.52s) is less than 10 seconds.
2025-10-19 17:04:32,762 - WARNING - mdxc_separator - Automatically enabling override_model_segment_size for better processing of short audio.
2025-10-19 17:04:32,800 - ERROR - separator - Failed to process file C:\Users\LENOVO.USER\AppData\Local\Temp\gradio\1a7047172a56351cd4d426b0b84c529451fc5ede933d19d25736bb37076c3cea\audio.wav: stereo needs to be set to True if passing in audio signal that is stereo (channel dimension of 2). also need to be False if mono (channel dimension of 1)
```
I found this on Music Source Separation docs, but unsure how to fix this in audio-separator code.
<img width="617" height="850" alt="image" src="https://github.com/user-attachments/assets/afc14f74-3dbb-4825-b71e-2735d72cf79a" />

**BS Roformer | Instrumental FNO by unwa**, but I faced a problem with torch.load, it seems like this model was trained with code that uses torch <2.6 or smt like that
```
2025-10-19 17:12:09,894 - ERROR - separator - Failed to instantiate Roformer model: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
        WeightsUnpickler error: Unsupported global: GLOBAL torch._C._nn.gelu was not an allowed global by default. Please use `torch.serialization.add_safe_globals([torch._C._nn.gelu])` or the `torch.serialization.safe_globals([torch._C._nn.gelu])` context manager to allowlist this global if you trust this class/function.
```
And about this I found this on docs and creator's repo:
<img width="657" height="591" alt="image" src="https://github.com/user-attachments/assets/b19add5e-d8ed-498e-87be-ba10a2dc5628" />
https://huggingface.co/pcunwa/BS-Roformer-Inst-FNO

**MelBand Roformer | Guitar by becruily**, also tried to add the guitar model by becruily again but I faced a long mask_estimator mismatch without any specific error like the model above.

---
About the models I tried to add but didn't work, the most useful is the first one, but support for mono audio should be added if I'm not wrong, because currently it seems to convert everything to stereo, and I think this is the problem. I'm not entirely sure tho.
Regarding the second model, I'm not sure if adding something like the error message indicates could lead to vulnerabilities in the case of malware-ridden models. In any case, this model isn't that useful.
Regarding the third model, I have no clue, tbh. Even after adding the mlp_expansion_factor, which was the original problem, there's now a mismatch.

I hope this information is helpful; you're doing a great job! 