### PR TITLE
Fix CI disk space issue on Ubuntu runners

### DIFF
--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -12,6 +12,17 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout project
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Fixes #252 - "no space left on device" error in PR CI checks
- Adds `jlumbroso/free-disk-space` action to Ubuntu test jobs
- Removes unnecessary pre-installed software (Android SDK, .NET, Haskell, Docker images, swap) before running tests
- Frees up ~20GB of disk space to prevent runner disk exhaustion

## Test plan
- [ ] Verify the unit tests workflow passes on all Ubuntu matrix jobs (3.10, 3.11, 3.12, 3.13)
- [ ] Confirm no "no space left on device" errors in workflow logs

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)