### PR TITLE
fix: use valid nvidia-smi query fields in CI

### DIFF
--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -40,8 +40,8 @@ jobs:
           echo "=== GPU Info ==="
           nvidia-smi
           echo ""
-          echo "=== CUDA Version ==="
-          nvidia-smi --query-gpu=driver_version,cuda_version --format=csv,noheader
+          echo "=== Driver Version ==="
+          nvidia-smi --query-gpu=driver_version,name,memory.total --format=csv,noheader
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Fix the `nvidia-smi --query-gpu` call in the GPU verification step — `cuda_version` is not a valid query field. Use `driver_version,name,memory.total` instead.

This was causing the integration test job to fail immediately before any tests ran.

## Test plan

- [ ] Integration test passes the GPU verification step
- [ ] Tests actually run on GPU runner

<!-- @coderabbitai ignore -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)