### PR TITLE
chore: bump version to 0.42.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "audio-separator"
-version = "0.42.0"
+version = "0.42.1"
 description = "Easy to use audio stem separation, using various models from UVR trained primarily by @Anjok07"
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,7 +16,7 @@ def mock_distribution():
     def side_effect(package_name):
         if package_name == "audio-separator":
             mock_dist = MagicMock()
-            mock_dist.version = "0.42.0"
+            mock_dist.version = "0.42.1"
             return mock_dist
         return original_distribution(package_name)
 


### PR DESCRIPTION
@coderabbitai ignore

## Summary

Patch release `0.42.1` for:
- **Bug fix:** Chunk overwrite when using `custom_output_names` with `chunk_duration` (#259, #270)
- **Docs:** Clarify demucs `segment_size` "Default" values (#264, #270)

## Test plan

- [x] Version string updated in `pyproject.toml` and `tests/unit/test_cli.py`
- [x] CI will verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)