### PR TITLE
Fix ONNX Runtime CUDA fallback by preloading shared library dependencies

### DIFF
--- a/audio_separator/separator/architectures/mdx_separator.py
+++ b/audio_separator/separator/architectures/mdx_separator.py
@@ -120,6 +120,18 @@ class MDXSeparator(CommonSeparator):
                 ort_session_options.log_severity_level = 0
 
             ort_inference_session = ort.InferenceSession(self.model_path, providers=self.onnx_execution_provider, sess_options=ort_session_options)
+            session_providers = ort_inference_session.get_providers()
+
+            requested_provider = self.onnx_execution_provider[0] if self.onnx_execution_provider else None
+            if requested_provider and requested_provider not in session_providers:
+                self.logger.warning(
+                    f"ONNX Runtime could not activate requested provider {requested_provider}; "
+                    f"session is using {session_providers}. This usually means required CUDA/cuDNN "
+                    f"runtime libraries are not visible to the dynamic loader."
+                )
+            else:
+                self.logger.debug(f"ONNX Runtime session providers: {session_providers}")
+
             self.model_run = lambda spek: ort_inference_session.run(None, {"input": spek.cpu().numpy()})[0]
             self.logger.debug("Model loaded successfully using ONNXruntime inferencing session.")
         else:

--- a/audio_separator/separator/separator.py
+++ b/audio_separator/separator/separator.py
@@ -321,7 +321,25 @@ class Separator:
         system_info = self.get_system_info()
         self.check_ffmpeg_installed()
         self.log_onnxruntime_packages()
+        self.preload_onnxruntime_dependencies()
         self.setup_torch_device(system_info)
+
+    def preload_onnxruntime_dependencies(self):
+        """
+        Preload ONNX Runtime shared library dependencies when supported by the installed package.
+
+        This helps pip-installed CUDA/cuDNN runtime wheels become visible to ONNX Runtime before
+        the first CUDAExecutionProvider session is created.
+        """
+        if not hasattr(ort, "preload_dlls"):
+            self.logger.debug("Installed ONNX Runtime does not provide preload_dlls(); skipping dependency preload.")
+            return
+
+        try:
+            ort.preload_dlls()
+            self.logger.debug("Preloaded ONNX Runtime shared library dependencies.")
+        except Exception as exc:
+            self.logger.warning(f"Unable to preload ONNX Runtime shared library dependencies: {exc}")
 
     def get_system_info(self):
         """

--- a/audio_separator/utils/cli.py
+++ b/audio_separator/utils/cli.py
@@ -150,13 +150,13 @@ def main():
         log_level = getattr(logging, args.log_level.upper())
     logger.setLevel(log_level)
 
-    from audio_separator.separator import Separator
-
     if args.env_info:
+        from audio_separator.separator import Separator
         separator = Separator()
         sys.exit(0)
 
     if args.list_models:
+        from audio_separator.separator import Separator
         separator = Separator(info_only=True)
 
         if args.list_format == "json":
@@ -190,6 +190,7 @@ def main():
         sys.exit(0)
 
     if args.list_presets:
+        from audio_separator.separator import Separator
         separator = Separator(info_only=True)
         presets = separator.list_ensemble_presets()
 
@@ -217,6 +218,7 @@ def main():
         sys.exit(0)
 
     if args.download_model_only:
+        from audio_separator.separator import Separator
         models_to_download = [args.model_filename] + (args.extra_models or [])
         separator = Separator(log_formatter=log_formatter, log_level=log_level, model_file_dir=args.model_file_dir)
         for model in models_to_download:
@@ -232,6 +234,8 @@ def main():
         sys.exit(1)
 
     logger.info(f"Separator version {package_version} beginning with input path(s): {', '.join(audio_files)}")
+
+    from audio_separator.separator import Separator
 
     separator = Separator(
         log_formatter=log_formatter,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -60,8 +60,15 @@ def test_cli_version_subprocess():
 
 # Test the CLI with no arguments
 def test_cli_no_args(capsys):
-    # Skip subprocess CLI tests - require proper CLI installation  
-    pytest.skip("CLI subprocess tests require proper installation")
+    test_args = ["cli.py"]
+
+    with patch("sys.argv", test_args), patch.dict("sys.modules", {"audio_separator.separator": None}):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Separate audio file into different stems." in captured.out
 
 
 # Test with multiple filename arguments

--- a/tests/unit/test_gpu_runtime_setup.py
+++ b/tests/unit/test_gpu_runtime_setup.py
@@ -9,7 +9,7 @@ def test_setup_accelerated_inferencing_device_preloads_onnxruntime_dependencies(
 
     with patch.object(separator, "get_system_info", return_value=system_info), patch.object(separator, "check_ffmpeg_installed"), patch.object(
         separator, "log_onnxruntime_packages"
-    ), patch("audio_separator.separator.separator.ort.preload_dlls") as mock_preload, patch.object(separator, "setup_torch_device") as mock_setup:
+    ), patch("audio_separator.separator.separator.ort.preload_dlls", create=True) as mock_preload, patch.object(separator, "setup_torch_device") as mock_setup:
         separator.setup_accelerated_inferencing_device()
 
     mock_preload.assert_called_once_with()
@@ -22,7 +22,7 @@ def test_setup_accelerated_inferencing_device_continues_when_preload_fails():
 
     with patch.object(separator, "get_system_info", return_value=system_info), patch.object(separator, "check_ffmpeg_installed"), patch.object(
         separator, "log_onnxruntime_packages"
-    ), patch("audio_separator.separator.separator.ort.preload_dlls", side_effect=RuntimeError("boom")), patch.object(
+    ), patch("audio_separator.separator.separator.ort.preload_dlls", side_effect=RuntimeError("boom"), create=True), patch.object(
         separator, "setup_torch_device"
     ) as mock_setup, patch.object(separator.logger, "warning") as mock_warning:
         separator.setup_accelerated_inferencing_device()

--- a/tests/unit/test_gpu_runtime_setup.py
+++ b/tests/unit/test_gpu_runtime_setup.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from audio_separator.separator.separator import Separator
+
+
+def test_setup_accelerated_inferencing_device_preloads_onnxruntime_dependencies():
+    separator = Separator(info_only=True)
+    system_info = object()
+
+    with patch.object(separator, "get_system_info", return_value=system_info), patch.object(separator, "check_ffmpeg_installed"), patch.object(
+        separator, "log_onnxruntime_packages"
+    ), patch("audio_separator.separator.separator.ort.preload_dlls") as mock_preload, patch.object(separator, "setup_torch_device") as mock_setup:
+        separator.setup_accelerated_inferencing_device()
+
+    mock_preload.assert_called_once_with()
+    mock_setup.assert_called_once_with(system_info)
+
+
+def test_setup_accelerated_inferencing_device_continues_when_preload_fails():
+    separator = Separator(info_only=True)
+    system_info = object()
+
+    with patch.object(separator, "get_system_info", return_value=system_info), patch.object(separator, "check_ffmpeg_installed"), patch.object(
+        separator, "log_onnxruntime_packages"
+    ), patch("audio_separator.separator.separator.ort.preload_dlls", side_effect=RuntimeError("boom")), patch.object(
+        separator, "setup_torch_device"
+    ) as mock_setup, patch.object(separator.logger, "warning") as mock_warning:
+        separator.setup_accelerated_inferencing_device()
+
+    mock_setup.assert_called_once_with(system_info)
+    mock_warning.assert_called_once()


### PR DESCRIPTION
  ## Summary

  This PR improves GPU initialization for ONNX Runtime in pip-based CUDA environments by preloading
  shared library dependencies before provider setup.

  It also adds a clearer warning when an ONNX Runtime session cannot activate the requested
  execution provider, and defers CLI imports so `audio-separator` help/usage paths do not eagerly
  trigger heavy runtime initialization.

  ## Problem

  In some Linux environments where CUDA and cuDNN are installed via pip wheels, `onnxruntime-gpu`
  may report `CUDAExecutionProvider` as available, but actual ONNX sessions can still fall back to
  CPU because the required shared libraries are not visible to the dynamic loader at session
  creation time.

  In this case, users may see errors similar to:

  - `Failed to load library ... libonnxruntime_providers_cuda.so`
  - `libcudnn.so.9: cannot open shared object file`
  - `Failed to create CUDAExecutionProvider`

  This can be confusing because PyTorch may still detect and use CUDA successfully, while ONNX
  Runtime silently falls back to CPU for ONNX models.

  ## Root Cause

  The CUDA/cuDNN runtime libraries provided by pip-installed NVIDIA wheels are not always discovered
  automatically by ONNX Runtime before the first CUDA execution provider session is created.

  ## Changes

  - Call `onnxruntime.preload_dlls()` during accelerated device setup when the installed ONNX
  Runtime version supports it.
  - Add a warning in the MDX ONNX loading path when the requested execution provider is not actually
  activated by the created session.
  - Defer importing `Separator` in the CLI until it is actually needed, so no-argument/help flows do
  not eagerly trigger ONNX Runtime initialization.
  - Add unit coverage for the ONNX Runtime dependency preload path and for the CLI no-argument
  behavior.

  ## Why this helps

  This makes pip-installed CUDA/cuDNN runtimes visible to ONNX Runtime earlier in the startup flow,
  which avoids a common failure mode where ONNX Runtime advertises CUDA support but then creates
  CPU-only sessions in practice.

  It also makes provider fallback much more obvious in logs, which should make future GPU
  troubleshooting easier.

  ## Validation

  Validated locally with a pip-based GPU environment on Linux using:

  - Python 3.12
  - PyTorch `2.11.0+cu130`
  - `onnxruntime-gpu` `1.24.4`

  Before this change:
  - PyTorch detected CUDA successfully.
  - ONNX Runtime exposed `CUDAExecutionProvider` in provider discovery.
  - A minimal ONNX `InferenceSession(..., providers=["CUDAExecutionProvider"])` failed to load CUDA
  dependencies and fell back to `CPUExecutionProvider`.

  After this change:
  - The same environment successfully created an ONNX Runtime session using `CUDAExecutionProvider`
  without requiring a manual `LD_LIBRARY_PATH` workaround.

  ## Notes

  This PR is focused on CUDA dependency loading and provider activation.

  It does **not** attempt to address unrelated ONNX Runtime device discovery warnings such as Linux
  DRM probing messages (for example, `/sys/class/drm/card0/device/vendor` on systems where `card0`
  is a framebuffer device rather than the NVIDIA device).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better ONNX Runtime provider diagnostics with warnings when requested acceleration providers are unavailable.
  * Added ONNX Runtime dependency preloading to improve GPU acceleration reliability.
  * CLI imports and error handling improved to surface missing-dependency/help messaging reliably.

* **Tests**
  * Added unit tests covering GPU runtime setup, dependency preloading failure handling, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->