### PR TITLE
fix: send multipart encoding when using gcs_uri

### DIFF
--- a/audio_separator/remote/api_client.py
+++ b/audio_separator/remote/api_client.py
@@ -149,9 +149,14 @@ class AudioSeparatorAPIClient:
 
         try:
             # Increase timeout for large files (5 minutes)
+            # When using gcs_uri (no file upload), we still need multipart/form-data
+            # encoding because FastAPI requires it for endpoints with File()/Form() params.
+            # Passing a dummy empty file field forces requests to use multipart encoding.
+            if not files:
+                files = {"file": ("", b"", "application/octet-stream")}
             response = self.session.post(
                 f"{self.api_url}/separate",
-                files=files if files else None,
+                files=files,
                 data=data,
                 timeout=300,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "audio-separator"
-version = "0.44.0"
+version = "0.44.1"
 description = "Easy to use audio stem separation, using various models from UVR trained primarily by @Anjok07"
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_remote_api_client.py
+++ b/tests/unit/test_remote_api_client.py
@@ -536,9 +536,10 @@ class TestAudioSeparatorAPIClient:
 
         assert result["task_id"] == "test-task-gcs"
 
-        # Verify gcs_uri was sent in form data, no file upload
+        # Verify gcs_uri was sent in form data
         call_args = mock_post.call_args
-        assert call_args[1]["files"] is None
+        # A dummy empty file is sent to force multipart encoding (FastAPI requires it)
+        assert call_args[1]["files"]["file"][0] == ""  # empty filename
         assert call_args[1]["data"]["gcs_uri"] == "gs://my-bucket/path/to/audio.flac"
 
     def test_separate_audio_requires_file_or_gcs_uri(self, api_client):


### PR DESCRIPTION
## Summary
Fix 400 Bad Request when using `gcs_uri` parameter on the `/separate` endpoint.

FastAPI requires `multipart/form-data` for endpoints with `File()`/`Form()` params. When `gcs_uri` was used without a file upload, the requests library defaulted to `application/x-www-form-urlencoded`, which FastAPI rejected.

Fix: send a dummy empty file field to force multipart encoding.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)