### PR TITLE
chore(ci): trigger GPU integration tests on ephemeral runners

### DIFF
--- a/audio_separator/separator/__init__.py
+++ b/audio_separator/separator/__init__.py
@@ -1,1 +1,3 @@
+# Trivial comment to trigger GPU integration tests on ephemeral self-hosted
+# runners after the 2026-05-17 dispatcher fix. Safe to remove on next edit.
 from .separator import Separator


### PR DESCRIPTION
## Summary

- Exercises the ephemeral n1+T4 GPU runner path after the dispatcher fix landed in nomadkaraoke/karaoke-gen#776.
- The n1 (GPU) family was *not* affected by the e2 bug there — n1 supports `onHostMaintenance=TERMINATE` (required because attached GPUs can't live-migrate) — but it hasn't been exercised under the ephemeral dispatcher since cutover (2026-05-17T04:56Z), so this is the verification PR.
- The comment touch in `audio_separator/separator/__init__.py` flips the `audio_separator/**` path filter to make `dorny/paths-filter` run all three integration test jobs.

## Test plan

- [ ] `ensemble-presets`, `core-models`, `stems-and-quality` all dispatch on freshly-created ephemeral n1+T4 VMs
- [ ] Each job completes within ~15 min and verifies pre-cached models load from `/opt/audio-separator-models`
- [ ] No long-lived ephemeral VMs after completion (orphan-cleanup tick within 30 min)

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)