### PR TITLE
ci: verify ephemeral GPU runner end-to-end

### DIFF
--- a/audio_separator/separator/__init__.py
+++ b/audio_separator/separator/__init__.py
@@ -1,1 +1,5 @@
 from .separator import Separator
+
+# No-op touch (2026-05-18): trigger the run-integration-tests workflow to
+# verify the new gha-runner-gpu image + secure-boot-off ephemeral dispatcher
+# load the NVIDIA driver cleanly at boot. See karaoke-gen PR #781.


### PR DESCRIPTION
## Summary

End-to-end verification for [karaoke-gen PR #781](https://github.com/nomadkaraoke/karaoke-gen/pull/781) — the GPU image NVIDIA driver-load fix.

This PR is a single-line touch on `audio_separator/separator/__init__.py` whose only purpose is to trigger `run-integration-tests.yaml`'s three self-hosted GPU jobs (`ensemble-presets`, `core-models`, `stems-and-quality`).

### Expected behaviour

For each of the three jobs the ephemeral GHA runner dispatcher should:

1. Create a fresh GCE VM from the `gha-runner-gpu` image family (latest is `gha-runner-gpu-20260518-035713`).
2. Create it with Secure Boot OFF (per the `enable_secure_boot=not family.has_gpu` change in #781).
3. On first boot, `gha-gpu-modprobe.service` rebuilds nvidia.ko via DKMS against the running kernel (kernel skew between image-build and runtime is now handled), modprobes nvidia/nvidia_uvm/nvidia_drm, and verifies with `nvidia-smi`.
4. The "Verify GPU availability" step (`nvidia-smi --query-gpu=driver_version,name,memory.total --format=csv,noheader`) succeeds.
5. The actual integration tests run.

### Smoke result before this PR

A smoke VM created by hand from `gha-runner-gpu-20260518-035713` (SB off) booted successfully and `nvidia-smi` reported `Tesla T4 / driver 595.71.05 / CUDA 13.2` as both root and as the `runner` user. Total boot-to-GPU-ready time: ~2 minutes.

### Test plan

- [ ] All three self-hosted GPU jobs pass (`ensemble-presets`, `core-models`, `stems-and-quality`)
- [ ] Each job's "Verify GPU availability" step output shows the T4
- [ ] No "Failed to query NVIDIA devices" or "Key was rejected by service" entries in the runner logs

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)