### PR TITLE
fix: honor MSST MDXC inference defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,8 +521,8 @@ Demucs Architecture Parameters:
 MDXC Architecture Parameters:
   --mdxc_segment_size MDXC_SEGMENT_SIZE                  Larger consumes more resources, but may give better results (default: 256). Example: --mdxc_segment_size=256
   --mdxc_override_model_segment_size                     Override model default segment size instead of using the model default value. Example: --mdxc_override_model_segment_size
-  --mdxc_overlap MDXC_OVERLAP                            Amount of overlap between prediction windows, 2-50. Higher is better but slower (default: 8). Example: --mdxc_overlap=8
-  --mdxc_batch_size MDXC_BATCH_SIZE                      Larger consumes more RAM but may process slightly faster (default: 1). Example: --mdxc_batch_size=4
+  --mdxc_overlap MDXC_OVERLAP                            Number of overlapping prediction windows, 2-50. Higher is better but slower (default: model config, falling back to 8). Example: --mdxc_overlap=8
+  --mdxc_batch_size MDXC_BATCH_SIZE                      Larger consumes more RAM but may process slightly faster (default: model config, falling back to 1). Example: --mdxc_batch_size=4
   --mdxc_pitch_shift MDXC_PITCH_SHIFT                    Shift audio pitch by a number of semitones while processing. May improve output for deep/high vocals. (default: 0). Example: --mdxc_pitch_shift=2
 ```
 
@@ -673,7 +673,7 @@ You can also rename specific stems:
 - **`mdx_params`:** (Optional) MDX Architecture Specific Attributes & Defaults. `Default: {"hop_length": 1024, "segment_size": 256, "overlap": 0.25, "batch_size": 1, "enable_denoise": False}`
 - **`vr_params`:** (Optional) VR Architecture Specific Attributes & Defaults. `Default: {"batch_size": 1, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False}`
 - **`demucs_params`:** (Optional) Demucs Architecture Specific Attributes & Defaults. `Default: {"segment_size": "Default", "shifts": 2, "overlap": 0.25, "segments_enabled": True}` _(Note: `segment_size` "Default" uses the model's internal default, typically 40 for older Demucs models and 10 for Demucs v4/htdemucs)_
-- **`mdxc_params`:** (Optional) MDXC Architecture Specific Attributes & Defaults. `Default: {"segment_size": 256, "override_model_segment_size": False, "batch_size": 1, "overlap": 8, "pitch_shift": 0}`
+- **`mdxc_params`:** (Optional) MDXC Architecture Specific Attributes & Defaults. `Default: {"segment_size": 256, "override_model_segment_size": False, "batch_size": None, "overlap": None, "pitch_shift": 0}` (`None` uses the model YAML's `inference` value, falling back to `1` for batch size and `8` for overlap.)
 - **`ensemble_algorithm`:** (Optional) Algorithm to use for ensembling multiple models. `Default: 'avg_wave'`
 - **`ensemble_weights`:** (Optional) Weights for each model in the ensemble. `Default: None` (equal weights)
 - **`ensemble_preset`:** (Optional) Named ensemble preset (e.g. `'vocal_balanced'`, `'karaoke'`). Sets models, algorithm, and weights automatically. Use `Separator(info_only=True).list_ensemble_presets()` to see all. `Default: None`

--- a/audio_separator/remote/api_client.py
+++ b/audio_separator/remote/api_client.py
@@ -67,8 +67,8 @@ class AudioSeparatorAPIClient:
         # MDXC parameters
         mdxc_segment_size: int = 256,
         mdxc_override_model_segment_size: bool = False,
-        mdxc_overlap: int = 8,
-        mdxc_batch_size: int = 1,
+        mdxc_overlap: Optional[int] = None,
+        mdxc_batch_size: Optional[int] = None,
         mdxc_pitch_shift: int = 0,
     ) -> dict:
         """Submit audio separation job (asynchronous processing).
@@ -133,11 +133,14 @@ class AudioSeparatorAPIClient:
                 # MDXC parameters
                 "mdxc_segment_size": mdxc_segment_size,
                 "mdxc_override_model_segment_size": mdxc_override_model_segment_size,
-                "mdxc_overlap": mdxc_overlap,
-                "mdxc_batch_size": mdxc_batch_size,
                 "mdxc_pitch_shift": mdxc_pitch_shift,
             }
         )
+
+        if mdxc_overlap is not None:
+            data["mdxc_overlap"] = mdxc_overlap
+        if mdxc_batch_size is not None:
+            data["mdxc_batch_size"] = mdxc_batch_size
 
         # Add optional parameters only if they have non-default values
         if output_bitrate:
@@ -209,8 +212,8 @@ class AudioSeparatorAPIClient:
         demucs_segments_enabled: bool = True,
         mdxc_segment_size: int = 256,
         mdxc_override_model_segment_size: bool = False,
-        mdxc_overlap: int = 8,
-        mdxc_batch_size: int = 1,
+        mdxc_overlap: Optional[int] = None,
+        mdxc_batch_size: Optional[int] = None,
         mdxc_pitch_shift: int = 0,
     ) -> dict:
         """

--- a/audio_separator/remote/cli.py
+++ b/audio_separator/remote/cli.py
@@ -137,8 +137,8 @@ def main():
     mdxc_group = separate_parser.add_argument_group("MDXC Architecture Parameters")
     mdxc_group.add_argument("--mdxc_segment_size", type=int, default=256, help="MDXC segment size (default: %(default)s)")
     mdxc_group.add_argument("--mdxc_override_model_segment_size", action="store_true", help="Override MDXC model segment size")
-    mdxc_group.add_argument("--mdxc_overlap", type=int, default=8, help="MDXC overlap (default: %(default)s)")
-    mdxc_group.add_argument("--mdxc_batch_size", type=int, default=1, help="MDXC batch size (default: %(default)s)")
+    mdxc_group.add_argument("--mdxc_overlap", type=int, default=None, help="MDXC overlap (default: model config, falling back to 8)")
+    mdxc_group.add_argument("--mdxc_batch_size", type=int, default=None, help="MDXC batch size (default: model config, falling back to 1)")
     mdxc_group.add_argument("--mdxc_pitch_shift", type=int, default=0, help="MDXC pitch shift (default: %(default)s)")
 
     # Status command

--- a/audio_separator/remote/deploy_cloudrun.py
+++ b/audio_separator/remote/deploy_cloudrun.py
@@ -203,8 +203,8 @@ def separate_audio_sync(
     # MDXC parameters
     mdxc_segment_size: int = 256,
     mdxc_override_model_segment_size: bool = False,
-    mdxc_overlap: int = 8,
-    mdxc_batch_size: int = 1,
+    mdxc_overlap: Optional[int] = None,
+    mdxc_batch_size: Optional[int] = None,
     mdxc_pitch_shift: int = 0,
 ) -> dict:
     """Separate audio into stems. Runs synchronously (Cloud Run GPU handles one job at a time)."""
@@ -440,8 +440,8 @@ async def separate_audio(
     # MDXC parameters
     mdxc_segment_size: int = Form(256),
     mdxc_override_model_segment_size: bool = Form(False),
-    mdxc_overlap: int = Form(8),
-    mdxc_batch_size: int = Form(1),
+    mdxc_overlap: Optional[int] = Form(None),
+    mdxc_batch_size: Optional[int] = Form(None),
     mdxc_pitch_shift: int = Form(0),
 ) -> dict:
     """Upload an audio file (or provide a GCS URI) and separate it into stems."""

--- a/audio_separator/remote/deploy_modal.py
+++ b/audio_separator/remote/deploy_modal.py
@@ -188,8 +188,8 @@ def separate_audio_function(
     # MDXC parameters
     mdxc_segment_size: int = 256,
     mdxc_override_model_segment_size: bool = False,
-    mdxc_overlap: int = 8,
-    mdxc_batch_size: int = 1,
+    mdxc_overlap: Optional[int] = None,
+    mdxc_batch_size: Optional[int] = None,
     mdxc_pitch_shift: int = 0,
 ) -> dict:
     """
@@ -575,8 +575,8 @@ async def separate_audio(
     # MDXC parameters
     mdxc_segment_size: int = Form(256, description="MDXC segment size"),
     mdxc_override_model_segment_size: bool = Form(False, description="Override MDXC model segment size"),
-    mdxc_overlap: int = Form(8, description="MDXC overlap"),
-    mdxc_batch_size: int = Form(1, description="MDXC batch size"),
+    mdxc_overlap: Optional[int] = Form(None, description="MDXC overlap"),
+    mdxc_batch_size: Optional[int] = Form(None, description="MDXC batch size"),
     mdxc_pitch_shift: int = Form(0, description="MDXC pitch shift"),
 ) -> dict:
     """

--- a/audio_separator/separator/architectures/mdxc_separator.py
+++ b/audio_separator/separator/architectures/mdxc_separator.py
@@ -374,6 +374,8 @@ class MDXCSeparator(CommonSeparator):
 
             # MDXC overlap is the number of overlapping prediction windows.
             step = chunk_size // self.overlap
+            if step <= 0:
+                raise ValueError(f"MDXC overlap ({self.overlap}) must not exceed chunk size ({chunk_size})")
             self.logger.debug(f"Step: {step} (overlap={self.overlap})")
 
             # Create a weighting table and convert it to a PyTorch tensor

--- a/audio_separator/separator/architectures/mdxc_separator.py
+++ b/audio_separator/separator/architectures/mdxc_separator.py
@@ -93,8 +93,13 @@ class MDXCSeparator(CommonSeparator):
         # The segment size is set based on the value provided in a chosen model's associated config file (yaml).
         self.override_model_segment_size = arch_config.get("override_model_segment_size", False)
 
-        self.overlap = arch_config.get("overlap", 8)
-        self.batch_size = arch_config.get("batch_size", 1)
+        inference_config = self.model_data.get("inference", {})
+        self.overlap = arch_config.get("overlap")
+        if self.overlap is None:
+            self.overlap = inference_config.get("num_overlap", 8)
+        self.batch_size = arch_config.get("batch_size")
+        if self.batch_size is None:
+            self.batch_size = inference_config.get("batch_size", 1)
 
         # Amount of pitch shift to apply during processing (this does NOT affect the pitch of the output audio):
         # • Whole numbers indicate semitones.
@@ -354,11 +359,9 @@ class MDXCSeparator(CommonSeparator):
                 f"Chunk size: {chunk_size} (using stft_hop_length={stft_hop_len} and dim_t={mdx_segment_size})"
             )
 
-            # Align step to chunk_size by default for Roformer to avoid stride mismatches
-            # If a user-specified overlap (in seconds) results in a step larger than chunk_size, clamp it
-            desired_step = int(self.overlap * self.model_data_cfgdict.audio.sample_rate)
-            step = chunk_size if desired_step <= 0 else min(desired_step, chunk_size)
-            self.logger.debug(f"Step: {step} (desired={desired_step})")
+            # MDXC overlap is the number of overlapping prediction windows.
+            step = chunk_size // self.overlap
+            self.logger.debug(f"Step: {step} (overlap={self.overlap})")
 
             # Create a weighting table and convert it to a PyTorch tensor
             window = torch.tensor(signal.windows.hamming(chunk_size), dtype=torch.float32)

--- a/audio_separator/separator/architectures/mdxc_separator.py
+++ b/audio_separator/separator/architectures/mdxc_separator.py
@@ -94,12 +94,25 @@ class MDXCSeparator(CommonSeparator):
         self.override_model_segment_size = arch_config.get("override_model_segment_size", False)
 
         inference_config = self.model_data.get("inference", {})
-        self.overlap = arch_config.get("overlap")
-        if self.overlap is None:
-            self.overlap = inference_config.get("num_overlap", 8)
-        self.batch_size = arch_config.get("batch_size")
-        if self.batch_size is None:
-            self.batch_size = inference_config.get("batch_size", 1)
+        overlap = arch_config.get("overlap")
+        if overlap is None:
+            overlap = inference_config.get("num_overlap")
+        if overlap is None:
+            overlap = 8
+
+        batch_size = arch_config.get("batch_size")
+        if batch_size is None:
+            batch_size = inference_config.get("batch_size")
+        if batch_size is None:
+            batch_size = 1
+
+        if overlap <= 0:
+            raise ValueError("MDXC overlap must be greater than zero")
+        if batch_size <= 0:
+            raise ValueError("MDXC batch size must be greater than zero")
+
+        self.overlap = overlap
+        self.batch_size = batch_size
 
         # Amount of pitch shift to apply during processing (this does NOT affect the pitch of the output audio):
         # • Whole numbers indicate semitones.

--- a/audio_separator/separator/separator.py
+++ b/audio_separator/separator/separator.py
@@ -111,8 +111,8 @@ class Separator:
     MDXC Architecture Specific Attributes & Defaults:
         segment_size: 256
         override_model_segment_size: False
-        batch_size: 1
-        overlap: 8
+        batch_size: None (uses inference.batch_size from the model YAML, falling back to 1)
+        overlap: None (uses inference.num_overlap from the model YAML, falling back to 8)
         pitch_shift: 0
     """
 
@@ -136,7 +136,7 @@ class Separator:
         mdx_params={"hop_length": 1024, "segment_size": 256, "overlap": 0.25, "batch_size": 1, "enable_denoise": False},
         vr_params={"batch_size": 1, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False},
         demucs_params={"segment_size": "Default", "shifts": 2, "overlap": 0.25, "segments_enabled": True},
-        mdxc_params={"segment_size": 256, "override_model_segment_size": False, "batch_size": 1, "overlap": 8, "pitch_shift": 0},
+        mdxc_params={"segment_size": 256, "override_model_segment_size": False, "batch_size": None, "overlap": None, "pitch_shift": 0},
         ensemble_algorithm=None,
         ensemble_weights=None,
         ensemble_preset=None,

--- a/audio_separator/utils/cli.py
+++ b/audio_separator/utils/cli.py
@@ -133,15 +133,15 @@ def main():
 
     mdxc_segment_size_help = "Larger consumes more resources, but may give better results (default: %(default)s). Example: --mdxc_segment_size=256"
     mdxc_override_model_segment_size_help = "Override model default segment size instead of using the model default value. Example: --mdxc_override_model_segment_size"
-    mdxc_overlap_help = "Amount of overlap between prediction windows, 2-50. Higher is better but slower (default: %(default)s). Example: --mdxc_overlap=8"
-    mdxc_batch_size_help = "Larger consumes more RAM but may process slightly faster (default: %(default)s). Example: --mdxc_batch_size=4"
+    mdxc_overlap_help = "Number of overlapping prediction windows, 2-50. Higher is better but slower (default: model config, falling back to 8). Example: --mdxc_overlap=8"
+    mdxc_batch_size_help = "Larger consumes more RAM but may process slightly faster (default: model config, falling back to 1). Example: --mdxc_batch_size=4"
     mdxc_pitch_shift_help = "Shift audio pitch by a number of semitones while processing. May improve output for deep/high vocals. (default: %(default)s). Example: --mdxc_pitch_shift=2"
 
     mdxc_params = parser.add_argument_group("MDXC Architecture Parameters")
     mdxc_params.add_argument("--mdxc_segment_size", type=int, default=256, help=mdxc_segment_size_help)
     mdxc_params.add_argument("--mdxc_override_model_segment_size", action="store_true", help=mdxc_override_model_segment_size_help)
-    mdxc_params.add_argument("--mdxc_overlap", type=int, default=8, help=mdxc_overlap_help)
-    mdxc_params.add_argument("--mdxc_batch_size", type=int, default=1, help=mdxc_batch_size_help)
+    mdxc_params.add_argument("--mdxc_overlap", type=int, default=None, help=mdxc_overlap_help)
+    mdxc_params.add_argument("--mdxc_batch_size", type=int, default=None, help=mdxc_batch_size_help)
     mdxc_params.add_argument("--mdxc_pitch_shift", type=int, default=0, help=mdxc_pitch_shift_help)
 
     args = parser.parse_args()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -51,7 +51,7 @@ def common_expected_args():
         "mdx_params": {"hop_length": 1024, "segment_size": 256, "overlap": 0.25, "batch_size": 1, "enable_denoise": False},
         "vr_params": {"batch_size": 1, "window_size": 512, "aggression": 5, "enable_tta": False, "enable_post_process": False, "post_process_threshold": 0.2, "high_end_process": False},
         "demucs_params": {"segment_size": "Default", "shifts": 2, "overlap": 0.25, "segments_enabled": True},
-        "mdxc_params": {"segment_size": 256, "batch_size": 1, "overlap": 8, "override_model_segment_size": False, "pitch_shift": 0},
+        "mdxc_params": {"segment_size": 256, "batch_size": None, "overlap": None, "override_model_segment_size": False, "pitch_shift": 0},
     }
 
 

--- a/tests/unit/test_mdxc_config.py
+++ b/tests/unit/test_mdxc_config.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock, patch
+
+import torch
+from ml_collections import ConfigDict
+
+from audio_separator.separator.architectures.mdxc_separator import MDXCSeparator
+from audio_separator.separator.common_separator import CommonSeparator
+
+
+def _make_separator(arch_config, inference_config=None):
+    separator = MDXCSeparator.__new__(MDXCSeparator)
+    separator.logger = Mock()
+    separator.model_data = {
+        "inference": inference_config or {},
+        "training": {"target_instrument": "Vocals"},
+    }
+    separator.torch_device = torch.device("cpu")
+    separator.torch_device_cpu = torch.device("cpu")
+
+    def load_model():
+        separator.model_data_cfgdict = ConfigDict(separator.model_data)
+
+    with patch.object(CommonSeparator, "__init__", return_value=None), patch.object(MDXCSeparator, "load_model", side_effect=load_model):
+        MDXCSeparator.__init__(separator, {}, arch_config)
+
+    return separator
+
+
+def test_mdxc_inference_defaults_come_from_model_config():
+    separator = _make_separator({"overlap": None, "batch_size": None}, {"num_overlap": 2, "batch_size": 4})
+
+    assert separator.overlap == 2
+    assert separator.batch_size == 4
+
+
+def test_mdxc_explicit_inference_options_override_model_config():
+    separator = _make_separator({"overlap": 8, "batch_size": 1}, {"num_overlap": 2, "batch_size": 4})
+
+    assert separator.overlap == 8
+    assert separator.batch_size == 1
+
+
+def test_mdxc_inference_defaults_fall_back_for_older_configs():
+    separator = _make_separator({"overlap": None, "batch_size": None})
+
+    assert separator.overlap == 8
+    assert separator.batch_size == 1

--- a/tests/unit/test_mdxc_config.py
+++ b/tests/unit/test_mdxc_config.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import pytest
 import torch
 from ml_collections import ConfigDict
 
@@ -45,3 +46,28 @@ def test_mdxc_inference_defaults_fall_back_for_older_configs():
 
     assert separator.overlap == 8
     assert separator.batch_size == 1
+
+
+def test_mdxc_null_inference_values_use_fallbacks():
+    separator = _make_separator({"overlap": None, "batch_size": None}, {"num_overlap": None, "batch_size": None})
+
+    assert separator.overlap == 8
+    assert separator.batch_size == 1
+
+
+@pytest.mark.parametrize(
+    ("arch_config", "inference_config", "message"),
+    [
+        ({"overlap": 0, "batch_size": 1}, {"num_overlap": 2}, "MDXC overlap"),
+        ({"overlap": -1, "batch_size": 1}, {"num_overlap": 2}, "MDXC overlap"),
+        ({"overlap": None, "batch_size": 1}, {"num_overlap": 0}, "MDXC overlap"),
+        ({"overlap": None, "batch_size": 1}, {"num_overlap": -1}, "MDXC overlap"),
+        ({"overlap": 2, "batch_size": 0}, {"batch_size": 1}, "MDXC batch size"),
+        ({"overlap": 2, "batch_size": -1}, {"batch_size": 1}, "MDXC batch size"),
+        ({"overlap": 2, "batch_size": None}, {"batch_size": 0}, "MDXC batch size"),
+        ({"overlap": 2, "batch_size": None}, {"batch_size": -1}, "MDXC batch size"),
+    ],
+)
+def test_mdxc_rejects_non_positive_inference_values(arch_config, inference_config, message):
+    with pytest.raises(ValueError, match=message):
+        _make_separator(arch_config, inference_config)

--- a/tests/unit/test_mdxc_roformer_chunking.py
+++ b/tests/unit/test_mdxc_roformer_chunking.py
@@ -9,7 +9,6 @@ import torch
 from unittest.mock import Mock, MagicMock, patch
 import logging
 
-
 class TestMDXCRoformerChunking:
     """Test cases for MDXC Roformer chunking and overlap functionality."""
 
@@ -38,29 +37,45 @@ class TestMDXCRoformerChunking:
         # Test implementation for chunking optimization - placeholder for future implementation
         pytest.skip("Chunking optimization not yet implemented")
 
-    def test_step_clamped_to_chunk_size(self):
-        """T053: Step clamped to chunk_size (desired_step > chunk_size or ≤ 0)."""
-        chunk_size = 8192
-        
-        # Test case 1: desired_step > chunk_size
-        desired_step_too_large = 10000
-        actual_step = min(desired_step_too_large, chunk_size)
-        assert actual_step == chunk_size
-        
-        # Test case 2: desired_step ≤ 0
-        desired_step_zero = 0
-        actual_step = max(desired_step_zero, chunk_size // 4)  # Use quarter chunk as minimum
-        assert actual_step == chunk_size // 4
-        
-        # Test case 3: desired_step negative
-        desired_step_negative = -100
-        actual_step = max(desired_step_negative, chunk_size // 4)
-        assert actual_step == chunk_size // 4
-        
-        # Test case 4: valid desired_step
-        desired_step_valid = 4096
-        actual_step = min(max(desired_step_valid, 1), chunk_size)
-        assert actual_step == desired_step_valid
+    def test_step_uses_overlap_divisor(self):
+        """T053: Step follows the MSST num_overlap divisor semantics."""
+        from ml_collections import ConfigDict
+
+        from audio_separator.separator.architectures.mdxc_separator import MDXCSeparator
+
+        class IdentityModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.anchor = torch.nn.Parameter(torch.zeros(1))
+
+            def forward(self, audio):
+                return audio.unsqueeze(1)
+
+        separator = MDXCSeparator.__new__(MDXCSeparator)
+        separator.pitch_shift = 0
+        separator.is_roformer = True
+        separator.override_model_segment_size = False
+        separator.model_data_cfgdict = ConfigDict(
+            {
+                "inference": {"dim_t": 5},
+                "training": {"target_instrument": "Vocals", "instruments": ["Vocals"]},
+                "model": {"stft_hop_length": 2},
+                "audio": {"hop_length": 2},
+            }
+        )
+        separator.overlap = 2
+        separator.model_run = IdentityModel()
+        separator.is_primary_stem_main_target = False
+        separator.logger = Mock()
+        chunk_starts = []
+
+        with patch(
+            "audio_separator.separator.architectures.mdxc_separator.tqdm",
+            side_effect=lambda values: chunk_starts.extend(values) or values,
+        ):
+            separator.demix(np.ones((2, 16), dtype=np.float32))
+
+        assert chunk_starts == [0, 4, 8, 12]
 
     def test_overlap_add_short_output_safe(self):
         """T054: overlap_add handles shorter model output safely (safe_len)."""

--- a/tests/unit/test_mdxc_roformer_chunking.py
+++ b/tests/unit/test_mdxc_roformer_chunking.py
@@ -77,6 +77,30 @@ class TestMDXCRoformerChunking:
 
         assert chunk_starts == [0, 4, 8, 12]
 
+    def test_overlap_larger_than_chunk_size_is_rejected(self):
+        """T053: Invalid overlap cannot produce a zero-sized RoFormer step."""
+        from ml_collections import ConfigDict
+
+        from audio_separator.separator.architectures.mdxc_separator import MDXCSeparator
+
+        separator = MDXCSeparator.__new__(MDXCSeparator)
+        separator.pitch_shift = 0
+        separator.is_roformer = True
+        separator.override_model_segment_size = False
+        separator.model_data_cfgdict = ConfigDict(
+            {
+                "inference": {"dim_t": 5},
+                "training": {"target_instrument": "Vocals", "instruments": ["Vocals"]},
+                "model": {"stft_hop_length": 2},
+                "audio": {"hop_length": 2},
+            }
+        )
+        separator.overlap = 9
+        separator.logger = Mock()
+
+        with pytest.raises(ValueError, match=r"MDXC overlap \(9\) must not exceed chunk size \(8\)"):
+            separator.demix(np.ones((2, 16), dtype=np.float32))
+
     def test_overlap_add_short_output_safe(self):
         """T054: overlap_add handles shorter model output safely (safe_len)."""
         # Create mock tensors

--- a/tests/unit/test_remote_api_client.py
+++ b/tests/unit/test_remote_api_client.py
@@ -73,6 +73,22 @@ class TestAudioSeparatorAPIClient:
         assert call_args[0][0] == "https://test-api.example.com/separate"
         assert "files" in call_args[1]
         assert "data" in call_args[1]
+        assert "mdxc_overlap" not in call_args[1]["data"]
+        assert "mdxc_batch_size" not in call_args[1]["data"]
+
+    @patch("requests.Session.post")
+    @patch("builtins.open", new_callable=mock_open, read_data=b"fake audio content")
+    def test_separate_audio_with_mdxc_overrides(self, mock_file, mock_post, api_client, mock_audio_file):
+        mock_response = Mock()
+        mock_response.json.return_value = {"task_id": "test-task-123", "status": "submitted"}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        api_client.separate_audio(mock_audio_file, mdxc_overlap=4, mdxc_batch_size=2)
+
+        data = mock_post.call_args[1]["data"]
+        assert data["mdxc_overlap"] == 4
+        assert data["mdxc_batch_size"] == 2
 
     @patch("requests.Session.post")
     @patch("builtins.open", new_callable=mock_open, read_data=b"fake audio content")


### PR DESCRIPTION
## Summary

PAS currently ignores the MDXC/RoFormer inference defaults in a model's YAML unless the user happens to supply the same values manually. It also interprets RoFormer overlap in different units from the model configuration and MSST.

This PR makes PAS use the model YAML's `inference.num_overlap` and `inference.batch_size` values by default, while preserving explicit user overrides and retaining PAS's existing fallback values for older YAML files that do not contain them.

## What was wrong

PAS was using the right-looking setting in the wrong way.

An MDXC model YAML can contain:

```yaml
inference:
  num_overlap: 2
  batch_size: 1
```

In MSST, `num_overlap` describes how many overlapping prediction windows fit into a chunk. The distance between chunk starts is therefore calculated as:

```text
step = chunk_size / num_overlap
```

For an 11-second chunk and `num_overlap: 2`, the next chunk starts 5.5 seconds later. That gives the intended 50% overlap.

PAS did two different things instead:

1. Its API and CLI defaults supplied `mdxc_overlap=8`, so the model's YAML value was not used.
2. The RoFormer path treated that value as a number of seconds and calculated the step as:

```text
step = overlap * sample_rate
```

For the same 11-second chunk, PAS therefore interpreted `8` as an 8-second step. Only 3 seconds were shared between adjacent chunks, or about 27.3% overlap.

The numerical values were especially misleading because identical numbers meant very different schedules:

| Value | Intended MSST meaning | Previous PAS RoFormer meaning |
| --- | --- | --- |
| `2` | 5.5-second step; 50% overlap | 2-second step; 81.8% overlap |
| `8` | 1.375-second step; 87.5% overlap | 8-second step; 27.3% overlap |

This meant PAS could appear substantially faster while not performing the inference schedule requested by the model author. It was doing less overlapping model work, which can also change separation quality.

## Performance impact

Correcting the calculation significantly reduces the apparent throughput compared with the previous, non-equivalent PAS behavior.

For a 126.71-second test input using an 11-second RoFormer chunk:

- Previous PAS overlap-8 behavior: **88.0 seconds**, RTF **0.695**
- Correct model-config behavior: **207.03 seconds**, RTF **1.634**
- A repeat with contiguous MPS inputs: **224.69 seconds**, RTF **1.773**

The previous schedule performed 16 model forwards, while the intended overlap-2 schedule performed 25. That is **56.25% more model inference work** before accounting for device throughput, memory movement, or benchmark noise.

The two corrected runs varied enough that 207–225 seconds should be treated as an approximate range rather than a definitive stable benchmark. However, the direction of the performance change is expected: the old 88-second result was faster because PAS was not applying the requested overlap, not because it was processing an equivalent workload more efficiently.

## Changes

- Default MDXC overlap and batch size to "not explicitly supplied" rather than forcing PAS values before the model is loaded.
- Resolve values in this order:
  1. explicit API/CLI/user override;
  2. model YAML (`inference.num_overlap` / `inference.batch_size`);
  3. existing PAS fallback (`8` / `1`) when the YAML does not specify a value.
- Calculate the RoFormer step using MSST's overlap-divisor semantics:

```python
step = chunk_size // self.overlap
```

- Carry the optional behavior through the local CLI, remote client, Cloud Run, and Modal entry points.
- Document the effective defaults.
- Add tests for YAML defaults, explicit overrides, legacy fallbacks, remote parameter omission, and the actual RoFormer chunk schedule.

## Scope

The incorrect seconds-based overlap calculation was in the RoFormer branch of the MDXC separator. The configuration precedence change applies to MDXC models so their existing YAML inference values are honored. Other architecture implementations are unchanged.

## Testing

- `293 passed, 7 skipped, 1 deselected`
- The deselected unit test downloads a model from GitHub and is unrelated to this change.
- `git diff --check` passed.
- Python compilation passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* MDXC separation now uses model-configured overlap and batch size when values aren’t provided.
* Explicit settings remain supported through the CLI, API, and deployment endpoints.
* Directory and batch processing now discovers audio files recursively and reports grouped failures.

## Bug Fixes
* Improved MDXC chunk processing and validation of invalid settings and outputs.
* Enhanced cleanup and audio output handling for more reliable separation.

## Documentation
* Updated CLI and parameter documentation to describe defaults and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
