### PR TITLE
fix: prioritize config for RoFormer model type detection

### DIFF
--- a/audio_separator/separator/common_separator.py
+++ b/audio_separator/separator/common_separator.py
@@ -519,9 +519,16 @@ class CommonSeparator:
         # Check for explicit Roformer flag
         if self.model_data.get("is_roformer", False):
             return True
+
+        # Prefer architecture-defining configuration over renameable paths.
+        from .roformer.configuration_normalizer import ConfigurationNormalizer
+
+        if ConfigurationNormalizer().detect_model_type(self.model_data) is not None:
+            return True
             
-        # Check model path for Roformer indicators
-        if self.model_path and "roformer" in self.model_path.lower():
+        # Keep filename-based compatibility without letting parent directories
+        # influence architecture routing.
+        if self.model_path and "roformer" in os.path.basename(self.model_path).lower():
             return True
             
         # Check model name for Roformer indicators

--- a/audio_separator/separator/roformer/README.md
+++ b/audio_separator/separator/roformer/README.md
@@ -104,7 +104,9 @@ print(f"Normalized config has {len(normalized)} parameters")
 
 ## Model Type Detection
 
-Detected via config contents (e.g., `freqs_per_bands` vs `num_bands`) and filename hints. Defaults to BSRoformer when ambiguous.
+The RoFormer family is resolved before family-specific defaults are applied. Architecture-defining configuration is authoritative: after supported nested sections and parameter aliases are normalized, `num_bands` identifies MelBand RoFormer and `freqs_per_bands` identifies BS-RoFormer.
+
+If the configuration does not identify a family, only explicit tokens in the checkpoint basename are considered; parent-directory names are ignored. Contradictory configuration markers fail validation. Configurations and basenames that provide no family evidence retain the legacy BS-RoFormer fallback with a warning.
 
 ## Integration with Audio Separator
 

--- a/audio_separator/separator/roformer/configuration_normalizer.py
+++ b/audio_separator/separator/roformer/configuration_normalizer.py
@@ -244,27 +244,106 @@ class ConfigurationNormalizer:
         Returns:
             Detected model type or None if cannot be determined
         """
-        # Check for BSRoformer-specific parameters
-        if 'freqs_per_bands' in config:
+        normalized = self._normalize_structure(copy.deepcopy(config), model_type="")
+        normalized = self._normalize_parameter_names(normalized)
+
+        has_bs_structure = 'freqs_per_bands' in normalized
+        has_mel_structure = 'num_bands' in normalized
+        if has_bs_structure and has_mel_structure:
+            raise ParameterValidationError.incompatible_parameters(
+                parameter_names=['num_bands', 'freqs_per_bands'],
+                issue_description='Configuration contains structural markers for both MelBand Roformer and BS-Roformer',
+                suggested_fix="Keep 'num_bands' for MelBand Roformer or 'freqs_per_bands' for BS-Roformer, but not both",
+                context='Roformer model type detection',
+            )
+
+        structural_type = None
+        structural_marker = None
+        if has_bs_structure:
+            structural_type = "bs_roformer"
+            structural_marker = "freqs_per_bands"
+        elif has_mel_structure:
+            structural_type = "mel_band_roformer"
+            structural_marker = "num_bands"
+
+        explicit_types = {}
+        for key in ('model_type', 'type', 'architecture'):
+            detected_type = self._detect_explicit_model_type(normalized.get(key))
+            if detected_type is not None:
+                explicit_types[key] = detected_type
+
+        if len(set(explicit_types.values())) > 1:
+            raise ParameterValidationError.incompatible_parameters(
+                parameter_names=list(explicit_types),
+                issue_description='Configuration contains conflicting explicit Roformer model types',
+                suggested_fix='Make all explicit Roformer model type fields agree',
+                context='Roformer model type detection',
+            )
+
+        explicit_key, explicit_type = next(iter(explicit_types.items()), (None, None))
+
+        if structural_type is not None and explicit_type is not None and structural_type != explicit_type:
+            raise ParameterValidationError.incompatible_parameters(
+                parameter_names=[explicit_key, structural_marker],
+                issue_description='Explicit model type conflicts with the architecture-defining parameter',
+                suggested_fix='Make the explicit model type agree with the structural Roformer parameters',
+                context='Roformer model type detection',
+            )
+
+        return structural_type or explicit_type
+
+    @staticmethod
+    def _detect_explicit_model_type(value: Any) -> Optional[str]:
+        """Return a Roformer family encoded in an explicit configuration field."""
+        if not isinstance(value, str):
+            return None
+
+        value_lower = value.lower()
+        if 'bs' in value_lower and 'roformer' in value_lower:
             return "bs_roformer"
-        
-        # Check for MelBandRoformer-specific parameters
-        if 'num_bands' in config or 'n_mels' in config or 'mel_bands' in config:
+        if 'mel' in value_lower and 'roformer' in value_lower:
             return "mel_band_roformer"
-        
-        # Check for model type hints in the config
-        model_type = config.get('model_type', config.get('type', config.get('architecture')))
-        if isinstance(model_type, str):
-            model_type_lower = model_type.lower()
-            if 'bs' in model_type_lower and 'roformer' in model_type_lower:
-                return "bs_roformer"
-            elif 'mel' in model_type_lower and 'roformer' in model_type_lower:
-                return "mel_band_roformer"
-            elif 'roformer' in model_type_lower:
-                # Default to BSRoformer if just "roformer"
-                return "bs_roformer"
-        
         return None
+
+    @staticmethod
+    def _file_basename(file_path: str) -> str:
+        """Return a lowercase basename for POSIX or Windows-style paths."""
+        return str(file_path).replace('\\', '/').rsplit('/', 1)[-1].lower()
+
+    def detect_model_type_from_filename(self, file_path: str) -> Optional[str]:
+        """Detect a Roformer family from explicit tokens in a checkpoint basename."""
+        filename = self._file_basename(file_path)
+        bs_tokens = ('bs_roformer', 'bs-roformer', 'bsroformer')
+        mel_tokens = (
+            'mel_band_roformer',
+            'mel-band-roformer',
+            'melband_roformer',
+            'melband-roformer',
+            'melbandroformer',
+            'mel_roformer',
+            'mel-roformer',
+        )
+
+        if any(token in filename for token in bs_tokens):
+            return "bs_roformer"
+        if any(token in filename for token in mel_tokens):
+            return "mel_band_roformer"
+        if 'roformer' in filename:
+            logger.warning(f"Generic 'roformer' detected in {filename}, defaulting to bs_roformer")
+            return "bs_roformer"
+        return None
+
+    def resolve_model_type(self, config: Dict[str, Any], file_path: str) -> str:
+        """Resolve one model family before family-specific defaults are applied."""
+        model_type = self.detect_model_type(config)
+        if model_type is None:
+            model_type = self.detect_model_type_from_filename(file_path)
+        if model_type is None:
+            model_type = "bs_roformer"
+            logger.warning(
+                f"Could not detect model type from config or checkpoint basename {file_path}, defaulting to bs_roformer"
+            )
+        return model_type
     
     def normalize_from_file_path(self, 
                                 config: Dict[str, Any], 
@@ -272,29 +351,17 @@ class ConfigurationNormalizer:
                                 apply_defaults: bool = True,
                                 validate: bool = True) -> Dict[str, Any]:
         """
-        Normalize configuration with model type detection from file path.
+        Normalize configuration after resolving the model type from config evidence.
         
         Args:
             config: Configuration dictionary
-            file_path: Path to the model file (used for type detection)
+            file_path: Path to the model file. Only its basename is used as a fallback
+                when the config does not identify a Roformer family.
             apply_defaults: Whether to apply defaults
             validate: Whether to validate
             
         Returns:
             Normalized configuration
         """
-        # Try to detect model type from file path
-        file_path_lower = file_path.lower()
-        if 'bs' in file_path_lower and 'roformer' in file_path_lower:
-            model_type = "bs_roformer"
-        elif 'mel' in file_path_lower and 'roformer' in file_path_lower:
-            model_type = "mel_band_roformer"
-        else:
-            # Try to detect from config
-            model_type = self.detect_model_type(config)
-            if model_type is None:
-                # Default to BSRoformer
-                model_type = "bs_roformer"
-                logger.warning(f"Could not detect model type from config or path {file_path}, defaulting to bs_roformer")
-        
+        model_type = self.resolve_model_type(config, file_path)
         return self.normalize_config(config, model_type, apply_defaults, validate)

--- a/audio_separator/separator/roformer/roformer_loader.py
+++ b/audio_separator/separator/roformer/roformer_loader.py
@@ -38,13 +38,13 @@ class RoformerLoader:
                    device: str = 'cpu') -> ModelLoadingResult:
         logger.info(f"Loading Roformer model from {model_path}")
         try:
-            normalized_config = self.config_normalizer.normalize_from_file_path(
-                config, model_path, apply_defaults=True, validate=True
+            model_type = self.config_normalizer.resolve_model_type(config, model_path)
+            normalized_config = self.config_normalizer.normalize_config(
+                config, model_type, apply_defaults=True, validate=True
             )
-            model_type = self.config_normalizer.detect_model_type(normalized_config)
             logger.debug(f"Detected model type: {model_type}")
-        except ParameterValidationError as e:
-            logger.error(f"Configuration validation failed: {e}")
+        except (ParameterValidationError, ValueError) as e:
+            logger.error(f"Model configuration resolution failed: {e}")
             return ModelLoadingResult.failure_result(
                 error_message=f"Config validation: {e}",
                 implementation=ImplementationVersion.NEW,
@@ -64,6 +64,7 @@ class RoformerLoader:
                 fallback_result = self._load_with_legacy_implementation(
                     model_path=model_path,
                     original_config=config,
+                    model_type=model_type,
                     device=device,
                     original_error=str(e)
                 )
@@ -217,6 +218,7 @@ class RoformerLoader:
     def _load_with_legacy_implementation(self,
                                           model_path: str,
                                           original_config: Dict[str, Any],
+                                          model_type: str,
                                           device: str,
                                           original_error: str) -> ModelLoadingResult:
         """
@@ -225,18 +227,23 @@ class RoformerLoader:
         """
         import torch
 
-        # Use nested 'model' section if present; otherwise assume flat
+        # Preserve the legacy constructor's original flat/model-section input.
         model_cfg = original_config.get('model', original_config)
+        model_cfg = self.config_normalizer.normalize_config(
+            model_cfg,
+            model_type,
+            apply_defaults=False,
+            validate=False,
+        )
 
-        # Determine model type from config
-        if 'num_bands' in model_cfg:
+        if model_type == "mel_band_roformer":
             from ..uvr_lib_v5.roformer.mel_band_roformer import MelBandRoformer
             model = MelBandRoformer(**model_cfg)
-        elif 'freqs_per_bands' in model_cfg:
+        elif model_type == "bs_roformer":
             from ..uvr_lib_v5.roformer.bs_roformer import BSRoformer
             model = BSRoformer(**model_cfg)
         else:
-            raise ValueError("Unknown Roformer model type in legacy configuration")
+            raise ValueError(f"Unknown Roformer model type in legacy configuration: {model_type}")
 
         # Load checkpoint as raw state dict (legacy behavior)
         try:
@@ -248,11 +255,13 @@ class RoformerLoader:
         model.load_state_dict(checkpoint)
         model.to(device).eval()
 
-        return ModelLoadingResult.fallback_success_result(
+        result = ModelLoadingResult.fallback_success_result(
             model=model,
             original_error=original_error,
             config=original_config,
         )
+        result.add_model_info('model_type', model_type)
+        return result
 
     def get_loading_stats(self) -> Dict[str, int]:
         return self._loading_stats.copy()
@@ -264,15 +273,10 @@ class RoformerLoader:
         }
 
     def detect_model_type(self, model_path: str) -> str:
-        model_path_lower = model_path.lower()
-        if any(indicator in model_path_lower for indicator in ['bs_roformer', 'bs-roformer', 'bsroformer']):
-            return "bs_roformer"
-        if any(indicator in model_path_lower for indicator in ['mel_band_roformer', 'mel-band-roformer', 'melband']):
-            return "mel_band_roformer"
-        if 'roformer' in model_path_lower:
-            logger.warning(f"Generic 'roformer' detected in {model_path}, defaulting to bs_roformer")
-            return "bs_roformer"
-        raise ValueError(f"Cannot determine Roformer model type from path: {model_path}")
+        model_type = self.config_normalizer.detect_model_type_from_filename(model_path)
+        if model_type is None:
+            raise ValueError(f"Cannot determine Roformer model type from path: {model_path}")
+        return model_type
 
     def get_default_configuration(self, model_type: str) -> Dict[str, Any]:
         if model_type == "bs_roformer":

--- a/audio_separator/separator/separator.py
+++ b/audio_separator/separator/separator.py
@@ -779,7 +779,11 @@ class Separator:
         model_data = yaml.load(open(model_data_yaml_filepath, encoding="utf-8"), Loader=yaml.FullLoader)
         self.logger.debug(f"Model data loaded from YAML file: {model_data}")
 
-        if "roformer" in model_data_yaml_filepath.lower():
+        from .roformer.configuration_normalizer import ConfigurationNormalizer
+
+        configured_roformer_type = ConfigurationNormalizer().detect_model_type(model_data)
+        yaml_filename = os.path.basename(model_data_yaml_filepath).lower()
+        if configured_roformer_type is not None or "roformer" in yaml_filename:
             model_data["is_roformer"] = True
 
         return model_data

--- a/tests/unit/test_configuration_normalizer.py
+++ b/tests/unit/test_configuration_normalizer.py
@@ -309,6 +309,7 @@ class TestConfigurationNormalizer:
         file_paths = [
             '/path/to/mel_band_roformer_model.ckpt',
             '/path/to/MelBand-Roformer-model.pth',
+            '/path/to/mel-roformer-vocals.ckpt',
             '/path/to/model_mel_roformer.bin'
         ]
         
@@ -319,7 +320,101 @@ class TestConfigurationNormalizer:
             
             # Should have MelBandRoformer defaults
             assert result['num_bands'] == 64, f"Failed for path: {file_path}"
-    
+
+    def test_nested_mel_config_is_not_overridden_by_parent_directory(self):
+        """A checkpoint's parent directory must not override its configured model family."""
+        config = {
+            'model': {
+                'dim': 384,
+                'depth': 12,
+                'num_bands': 60,
+            }
+        }
+
+        result = self.normalizer.normalize_from_file_path(
+            config,
+            '/tmp/absolute/roformer/mel_band_roformer_karaoke.ckpt',
+            apply_defaults=True,
+            validate=False,
+        )
+
+        assert result['num_bands'] == 60
+        assert 'freqs_per_bands' not in result
+
+    @pytest.mark.parametrize(
+        ('config', 'filename', 'expected_key', 'unexpected_key'),
+        [
+            (
+                {'model': {'dim': 384, 'depth': 12, 'num_bands': 60}},
+                'BS-Roformer-SW.ckpt',
+                'num_bands',
+                'freqs_per_bands',
+            ),
+            (
+                {'model': {'dim': 384, 'depth': 12, 'freqs_per_bands': (2, 4, 8, 16)}},
+                'mel_band_roformer_karaoke.ckpt',
+                'freqs_per_bands',
+                'num_bands',
+            ),
+        ],
+    )
+    def test_config_structure_overrides_conflicting_checkpoint_basename(
+        self,
+        config,
+        filename,
+        expected_key,
+        unexpected_key,
+    ):
+        """Architecture-defining config is authoritative when a checkpoint is renamed."""
+        result = self.normalizer.normalize_from_file_path(
+            config,
+            f'/tmp/{filename}',
+            apply_defaults=True,
+            validate=False,
+        )
+
+        assert expected_key in result
+        assert unexpected_key not in result
+
+    @pytest.mark.parametrize('section_name', ['model', 'architecture', 'params'])
+    def test_detect_model_type_flattens_supported_nested_sections(self, section_name):
+        """All supported nested config layouts expose their structural family marker."""
+        config = {section_name: {'num_bands': 60}}
+
+        assert self.normalizer.detect_model_type(config) == 'mel_band_roformer'
+
+    def test_detect_model_type_rejects_conflicting_structural_markers(self):
+        """A config that describes both Roformer families must fail before defaults are applied."""
+        config = {
+            'model': {
+                'num_bands': 60,
+                'freqs_per_bands': (2, 4, 8, 16, 32, 64),
+            }
+        }
+
+        with pytest.raises(ParameterValidationError, match='num_bands, freqs_per_bands'):
+            self.normalizer.detect_model_type(config)
+
+    def test_detect_model_type_rejects_explicit_type_that_conflicts_with_structure(self):
+        """An explicit family must agree with the architecture-defining parameters."""
+        config = {
+            'model_type': 'bs_roformer',
+            'model': {'num_bands': 60},
+        }
+
+        with pytest.raises(ParameterValidationError, match='model_type, num_bands'):
+            self.normalizer.detect_model_type(config)
+
+    def test_detect_model_type_rejects_conflicting_explicit_types(self):
+        """All recognized explicit family fields must agree."""
+        config = {
+            'model_type': 'bs_roformer',
+            'type': 'mel_band_roformer',
+        }
+
+        with pytest.raises(ParameterValidationError, match='model_type, type'):
+            self.normalizer.detect_model_type(config)
+
     def test_normalize_from_file_path_default_fallback(self):
         """Test normalization with file path detection - default fallback."""
         config = {

--- a/tests/unit/test_roformer_loader.py
+++ b/tests/unit/test_roformer_loader.py
@@ -1,0 +1,89 @@
+"""Behavior tests for the concrete Roformer loader."""
+
+from unittest.mock import Mock, patch
+
+from audio_separator.separator.roformer.roformer_loader import RoformerLoader
+from audio_separator.separator.roformer.model_loading_result import ImplementationVersion
+
+
+def test_detect_model_type_ignores_parent_directory():
+    """Path-only detection must use the checkpoint basename."""
+    loader = RoformerLoader()
+
+    model_type = loader.detect_model_type("/tmp/bs_roformer_experiment/mel_band_roformer_karaoke.ckpt")
+
+    assert model_type == "mel_band_roformer"
+
+
+def test_load_model_uses_nested_config_for_registry_model_without_family_in_filename():
+    """The concrete loader must select MelBand from config without using fallback."""
+    loader = RoformerLoader()
+    model = Mock()
+    loader._create_mel_band_roformer = Mock(return_value=model)
+    loader._create_bs_roformer = Mock()
+    config = {
+        "model": {
+            "dim": 384,
+            "depth": 12,
+            "num_bands": 60,
+        }
+    }
+
+    result = loader.load_model(
+        "/tmp/bs_roformer_experiment/dereverb_big_mbr_ep_362.ckpt",
+        config,
+    )
+
+    assert result.success is True
+    assert result.implementation_used is ImplementationVersion.NEW
+    assert result.model_info["model_type"] == "mel_band_roformer"
+    loader._create_mel_band_roformer.assert_called_once()
+    loader._create_bs_roformer.assert_not_called()
+
+
+def test_load_model_uses_nested_bs_config_despite_mel_parent_directory():
+    """The BS-Roformer-SW config remains authoritative in a misleading directory."""
+    loader = RoformerLoader()
+    model = Mock()
+    loader._create_bs_roformer = Mock(return_value=model)
+    loader._create_mel_band_roformer = Mock()
+    config = {
+        "model": {
+            "dim": 384,
+            "depth": 12,
+            "freqs_per_bands": (2, 4, 8, 16, 32, 64),
+        }
+    }
+
+    result = loader.load_model(
+        "/tmp/mel_band_roformer_experiment/BS-Roformer-SW.ckpt",
+        config,
+    )
+
+    assert result.success is True
+    assert result.implementation_used is ImplementationVersion.NEW
+    assert result.model_info["model_type"] == "bs_roformer"
+    loader._create_bs_roformer.assert_called_once()
+    loader._create_mel_band_roformer.assert_not_called()
+
+
+@patch("torch.load", return_value={})
+@patch("audio_separator.separator.uvr_lib_v5.roformer.mel_band_roformer.MelBandRoformer")
+def test_legacy_fallback_preserves_resolved_family_and_normalizes_aliases(mel_constructor, _torch_load):
+    """Legacy fallback must keep the resolved family and normalize model-section aliases."""
+    loader = RoformerLoader()
+    loader._load_with_new_implementation = Mock(side_effect=RuntimeError("new loader failed"))
+    mel_constructor.return_value = Mock()
+    config = {
+        "model": {
+            "dim": 384,
+            "depth": 12,
+            "n_mels": 60,
+        }
+    }
+
+    result = loader.load_model("/tmp/model.ckpt", config)
+
+    assert result.success is True
+    assert result.implementation_used is ImplementationVersion.FALLBACK
+    mel_constructor.assert_called_once_with(dim=384, depth=12, num_bands=60)

--- a/tests/unit/test_separator_detection.py
+++ b/tests/unit/test_separator_detection.py
@@ -7,6 +7,10 @@ import pytest
 from unittest.mock import Mock, patch, MagicMock
 import os
 import tempfile
+import yaml
+
+from audio_separator.separator.separator import Separator
+from audio_separator.separator.common_separator import CommonSeparator
 
 
 class TestSeparatorDetection:
@@ -20,6 +24,52 @@ class TestSeparatorDetection:
         """Clean up test fixtures."""
         import shutil
         shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_non_roformer_yaml_is_not_detected_from_parent_directory(self, tmp_path):
+        """A parent directory name must not turn an MDXC config into a Roformer config."""
+        config_dir = tmp_path / "roformer-experiment"
+        config_dir.mkdir()
+        config_path = config_dir / "model_2_stem_full_band_8k.yaml"
+        config_path.write_text(yaml.safe_dump({'model': {'dim': 128, 'depth': 4}}))
+
+        separator = Separator.__new__(Separator)
+        separator.model_file_dir = str(tmp_path)
+        separator.logger = Mock()
+
+        model_data = separator.load_model_data_from_yaml(str(config_path))
+
+        assert model_data.get('is_roformer', False) is False
+
+    def test_neutral_yaml_filename_uses_config_content_for_roformer_detection(self, tmp_path):
+        """A model family marker is sufficient even when the YAML was renamed."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump({'model': {'num_bands': 60}}))
+
+        separator = Separator.__new__(Separator)
+        separator.model_file_dir = str(tmp_path)
+        separator.logger = Mock()
+
+        model_data = separator.load_model_data_from_yaml(str(config_path))
+
+        assert model_data['is_roformer'] is True
+
+    def test_common_separator_ignores_checkpoint_parent_directory(self):
+        """CommonSeparator must not route a plain MDXC model by its storage directory."""
+        separator = CommonSeparator.__new__(CommonSeparator)
+        separator.model_data = {'model': {'dim': 128, 'depth': 4}}
+        separator.model_path = '/tmp/roformer-experiment/model.ckpt'
+        separator.model_name = 'model'
+
+        assert separator._detect_roformer_model() is False
+
+    def test_common_separator_uses_config_content_for_neutral_checkpoint_name(self):
+        """A renamed checkpoint remains a Roformer when its config is unambiguous."""
+        separator = CommonSeparator.__new__(CommonSeparator)
+        separator.model_data = {'model': {'num_bands': 60}}
+        separator.model_path = '/tmp/model.ckpt'
+        separator.model_name = 'model'
+
+        assert separator._detect_roformer_model() is True
 
     def test_is_roformer_set_from_yaml_path(self):
         """T059: YAML path containing 'roformer' sets is_roformer and routes Roformer path."""


### PR DESCRIPTION
## Summary

Fix RoFormer family detection so the model class is selected primarily from the YAML configuration rather than the checkpoint's absolute path.

Previously, moving a MelBand RoFormer checkpoint under a directory whose path contained both `bs` and `roformer` could make it load as `BSRoformer`. For example, `absolute` itself contains the substring `bs`:

`/tmp/absolute/roformer/mel_band_roformer_karaoke.ckpt`

RoFormer routing from YAML and checkpoint paths was similarly affected by parent-directory names.

## Background

- On February 24, 2025, [#177 (`2586c79`)](https://github.com/nomadkaraoke/python-audio-separator/commit/2586c79e274e01c5ef9154989700559c0b9b6778) added bundled MelBand dereverb checkpoints whose basenames use `mbr` rather than an explicit MelBand RoFormer token. These models demonstrate that a filename is not a complete architecture signal.
- On September 27, 2025, [#234 (`cec32b7`)](https://github.com/nomadkaraoke/python-audio-separator/commit/cec32b7349f2dd9d1ced77ff252f402bfbecc45a) introduced the normalized loader used for BS-Roformer-SW. Its family selection checked substring matches in the full checkpoint path before inspecting the configuration.

## Detection flow

### Before

```mermaid
flowchart TD
    A["Raw YAML config + absolute checkpoint path"]
    B{"Does the full path contain<br/>'bs' and 'roformer'?"}
    C["Select BS-Roformer"]
    D["Inspect only the raw top-level config"]
    E{"Family marker found?"}
    F["Default to BS-Roformer"]
    G["Select detected family"]
    H["Apply family-specific defaults"]
    I["Detect the family again<br/>from the normalized config"]
    J["Injected BS defaults confirm<br/>BS-Roformer"]
    K["Instantiate the wrong model class"]

    A --> B
    B -- Yes --> C
    B -- No --> D
    D --> E
    E -- No --> F
    E -- Yes --> G
    C --> H
    F --> H
    G --> H
    H --> I
    I --> J
    J --> K
```

For example, `/tmp/absolute/roformer/...` takes the BS branch because `absolute` contains the substring `bs`. Bundled YAML files also keep `num_bands` or `freqs_per_bands` under `model`, so inspecting only the raw top level misses the authoritative family marker.

### After

```mermaid
flowchart TD
    A["Raw YAML config + checkpoint path"]
    B["Flatten supported nested config sections"]
    C["Normalize parameter aliases"]
    D["Inspect structural and explicit config evidence"]
    E{"Does the config contain<br/>contradictory family markers?"}
    F["Raise ParameterValidationError"]
    G{"Does the config identify a family?"}
    H["Use the config-defined family"]
    I["Inspect explicit tokens in the<br/>checkpoint basename only"]
    J{"Known basename token?"}
    K["Use the basename-defined family"]
    L["Keep the legacy BS fallback<br/>and emit a warning"]
    M["Apply defaults once"]
    N["Use the same resolved family for<br/>new and legacy loading"]

    A --> B
    B --> C
    C --> D
    D --> E
    E -- Yes --> F
    E -- No --> G
    G -- Yes --> H
    G -- No --> I
    I --> J
    J -- Yes --> K
    J -- No --> L
    H --> M
    K --> M
    L --> M
    M --> N
```

The YAML configuration is authoritative because it describes the architecture required by the checkpoint. A filename or parent directory can be renamed without changing that architecture.

## Root cause

`ConfigurationNormalizer.normalize_from_file_path()` inspected the complete checkpoint path before inspecting normalized configuration contents:

- any path containing both `bs` and `roformer` was treated as BS-Roformer
- the check used unrestricted substring matching
- bundled RoFormer YAML files keep their architecture parameters under `model`, but model type detection did not flatten that section first
- family-specific defaults were applied using the incorrectly selected family
- the normalized config was detected a second time, at which point the injected BS defaults made the incorrect result self-reinforcing

This also affected three bundled MelBand models whose checkpoint basenames do not contain a family token (Issue #245):

- `dereverb_big_mbr_ep_362.ckpt`
- `dereverb_super_big_mbr_ep_346.ckpt`
- `dereverb_echo_mbr_fused.ckpt`

## Changes

- Resolve the RoFormer family before applying family-specific defaults.
- Flatten supported nested configuration sections for detection.
- Normalize existing aliases before detection:
  - `n_mels` / `mel_bands` → `num_bands`
  - `freq_bands` / `frequency_bands` → `freqs_per_bands`
- Treat `num_bands` as MelBand RoFormer evidence.
- Treat `freqs_per_bands` as BS-Roformer evidence.
- Validate the existing explicit `model_type`, `type`, and string `architecture` hints against structural parameters.
- Fail early when both BS and MelBand structural markers are present, or when an explicit family conflicts with the structural marker.
- Use explicit tokens from the checkpoint basename only when the config does not identify a family.
- Ignore checkpoint and YAML parent-directory names.
- Resolve the family once in `RoformerLoader.load_model()` and pass the same result to both the new and legacy loading paths.
- Detect RoFormer routing from config content first in `Separator` and `CommonSeparator`.
- Update the internal RoFormer documentation to distinguish contradictory configuration from an unknown-family fallback.

`models.json` does not require a schema change.

## Compatibility

- `normalize_from_file_path()` keeps its existing arguments and return type.
- Config evidence takes precedence over a conflicting checkpoint filename because filenames can be changed without changing the checkpoint architecture.
- Configurations and basenames that provide no family evidence retain the legacy BS-Roformer fallback with a warning.
- Configs containing both `num_bands` and `freqs_per_bands`, or an explicit family that conflicts with the structural marker, now fail during configuration validation instead of silently selecting one family.
- The legacy loader retains its existing flat or `model`-section input while using the same resolved family and normalized aliases as the new loader.

## Testing

- Unit and contract suite: **319 passed, 5 skipped**
- Concrete `RoformerLoader` tests verify:
  - only the expected MelBand or BS constructor is called
  - the new implementation succeeds without falling back
  - legacy fallback preserves the initially resolved family
  - legacy model-section aliases are normalized
- Routing tests cover both positive and negative detection through:
  - `Separator.load_model_data_from_yaml()`
  - `CommonSeparator._detect_roformer_model()`
- Validated the current `model-configs` release:
  - **30 MelBand RoFormer configs**
  - **12 BS-Roformer configs**
  - all normalized successfully with validation enabled
- Loaded real release checkpoints, including their state dicts:
  - MelBand Karaoke loaded as `MelBandRoformer` from an `absolute/roformer` parent directory
  - BS-Roformer-SW loaded as `BSRoformer` from a `mel-experiment` parent directory
  - both used the new implementation rather than legacy fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved RoFormer model detection using configuration details before filename hints.
  - Prevented parent-directory names from incorrectly identifying models as RoFormer.
  - Added validation for conflicting model-type indicators.
  - Improved identification of MelBand and BS RoFormer architectures.
  - Preserved reliable fallback behavior for ambiguous model configurations.
- **Documentation**
  - Clarified model-type detection rules and fallback behavior.
- **Tests**
  - Added coverage for nested configurations, misleading paths, neutral filenames, and legacy fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->