### PR TITLE
fix: preserve silent outputs and surface export failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The simplest (and probably most used) use case for this package is to separate a
     - [Full command-line interface options](#full-command-line-interface-options)
     - [As a Dependency in a Python Project](#as-a-dependency-in-a-python-project)
       - [Batch processing and processing with multiple models](#batch-processing-and-processing-with-multiple-models)
+      - [Output and error handling](#output-and-error-handling)
       - [Renaming Stems](#renaming-stems)
   - [Parameters for the Separator class](#parameters-for-the-separator-class)
   - [Remote API Usage 🌐](#remote-api-usage-)
@@ -582,6 +583,25 @@ separator.load_model(model_filename='model_bs_roformer_ep_317_sdr_12.9755.ckpt')
 # Separate all audio files located in a folder
 output_files = separator.separate('path/to/audio_directory')
 ```
+
+#### Output and error handling
+
+On success, every path returned by `separate()` refers to a fully written output file. Valid stems are written even when silent or near-silent; applications that want to suppress them should apply their own loudness policy.
+
+A string file path is processed as a single input and propagates failures immediately. A list or directory is treated as a batch: all discoverable inputs are attempted, then `BatchSeparationError` is raised if any failed.
+
+```python
+from audio_separator.separator import BatchSeparationError
+
+try:
+    output_files = separator.separate(['audio1.wav', 'audio2.wav'])
+except BatchSeparationError as error:
+    print(f"Completed files: {error.successful_files}")
+    for input_path, cause in error.failures:
+        print(f"{input_path}: {cause}")
+```
+
+`InvalidAudioDataError` and `AudioExportError` are available for callers that need to distinguish validation failures from output-publication failures.
 
 #### Renaming Stems
 

--- a/audio_separator/separator/__init__.py
+++ b/audio_separator/separator/__init__.py
@@ -1,1 +1,4 @@
 from .separator import Separator
+from .exceptions import AudioExportError, BatchSeparationError, InvalidAudioDataError
+
+__all__ = ["Separator", "InvalidAudioDataError", "AudioExportError", "BatchSeparationError"]

--- a/audio_separator/separator/__init__.py
+++ b/audio_separator/separator/__init__.py
@@ -1,4 +1,4 @@
 from .separator import Separator
 from .exceptions import AudioExportError, BatchSeparationError, InvalidAudioDataError
 
-__all__ = ["Separator", "InvalidAudioDataError", "AudioExportError", "BatchSeparationError"]
+__all__ = ["AudioExportError", "BatchSeparationError", "InvalidAudioDataError", "Separator"]

--- a/audio_separator/separator/architectures/demucs_separator.py
+++ b/audio_separator/separator/architectures/demucs_separator.py
@@ -168,7 +168,12 @@ class DemucsSeparator(CommonSeparator):
         processed = {}
         mix = torch.tensor(mix, dtype=torch.float32)
         ref = mix.mean(0)
-        mix = (mix - ref.mean()) / ref.std()
+        ref_mean = ref.mean()
+        ref_std = ref.std()
+        if not torch.isfinite(ref_std):
+            ref_std = torch.zeros_like(ref_std)
+        normalization_std = ref_std.clamp_min(torch.finfo(mix.dtype).eps)
+        mix = (mix - ref_mean) / normalization_std
         mix_infer = mix
 
         with torch.no_grad():
@@ -185,7 +190,7 @@ class DemucsSeparator(CommonSeparator):
                 progress=True,
             )[0]
 
-        sources = (sources * ref.std() + ref.mean()).cpu().numpy()
+        sources = (sources * ref_std + ref_mean).cpu().numpy()
         sources[[0, 1]] = sources[[1, 0]]
         processed[mix] = sources[:, :, 0:None].copy()
         sources = list(processed.values())

--- a/audio_separator/separator/audio_chunking.py
+++ b/audio_separator/separator/audio_chunking.py
@@ -5,6 +5,8 @@ import logging
 from typing import List
 from pydub import AudioSegment
 
+from audio_separator.separator.audio_io import atomic_output_path
+
 
 class AudioChunker:
     """
@@ -124,7 +126,11 @@ class AudioChunker:
         output_format = ext.lstrip('.') if ext else 'wav'
 
         self.logger.info(f"Exporting merged audio ({len(combined) / 1000:.1f}s) to {output_path}")
-        combined.export(output_path, format=output_format)
+        with atomic_output_path(output_path, "pydub") as temp_path:
+            export_handle = combined.export(temp_path, format=output_format)
+            close_export = getattr(export_handle, "close", None)
+            if callable(close_export):
+                close_export()
 
         return output_path
 

--- a/audio_separator/separator/audio_io.py
+++ b/audio_separator/separator/audio_io.py
@@ -1,0 +1,92 @@
+"""Shared atomic file publication for encoded audio outputs."""
+
+from contextlib import contextmanager
+import os
+import secrets
+import stat
+import tempfile
+
+import numpy as np
+
+from audio_separator.separator.exceptions import AudioExportError, InvalidAudioDataError
+
+
+def validate_audio_source(stem_source):
+    """Return audio as an array after validating mono/stereo frame layout."""
+    stem_source = np.asarray(stem_source)
+    if stem_source.ndim not in (1, 2) or (stem_source.ndim == 2 and stem_source.shape[1] not in (1, 2)):
+        raise InvalidAudioDataError(f"Audio data has invalid shape {stem_source.shape}; expected mono or stereo frames")
+    return stem_source
+
+
+def _published_file_mode(target_path, target_dir):
+    """Preserve an existing mode or derive a new-file mode through the current umask."""
+    if os.name == "nt":
+        return None
+    try:
+        return stat.S_IMODE(os.stat(target_path).st_mode)
+    except FileNotFoundError:
+        pass
+
+    for _ in range(10):
+        probe_path = os.path.join(target_dir, f".audio-output-mode-{secrets.token_hex(8)}")
+        try:
+            probe_fd = os.open(probe_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+        except FileExistsError:
+            continue
+        try:
+            return stat.S_IMODE(os.fstat(probe_fd).st_mode)
+        finally:
+            os.close(probe_fd)
+            os.unlink(probe_path)
+
+    raise FileExistsError("Could not create a unique mode probe for atomic audio output")
+
+
+@contextmanager
+def atomic_output_path(target_path, backend):
+    """Yield a same-directory temporary path and atomically publish it on success."""
+    temp_fd = None
+    temp_path = None
+    error = None
+
+    try:
+        target_dir = os.path.dirname(target_path) or "."
+        suffix = os.path.splitext(target_path)[1]
+        temp_fd, temp_path = tempfile.mkstemp(prefix=f".{os.path.basename(target_path)}.", suffix=suffix, dir=target_dir)
+        published_mode = _published_file_mode(target_path, target_dir)
+        if published_mode is not None:
+            os.fchmod(temp_fd, published_mode)
+        os.close(temp_fd)
+        temp_fd = None
+
+        yield temp_path
+
+        if not os.path.exists(temp_path) or os.path.getsize(temp_path) == 0:
+            raise OSError("Audio backend produced an empty output file")
+        os.replace(temp_path, target_path)
+    except Exception as exc:
+        error = exc
+    finally:
+        if temp_fd is not None:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_error:
+                if error is None:
+                    error = cleanup_error
+                elif hasattr(error, "add_note"):
+                    error.add_note(f"Failed to remove temporary audio output {temp_path}: {cleanup_error}")
+
+    if error is not None:
+        if isinstance(error, AudioExportError):
+            raise error
+        raise AudioExportError(
+            f"Failed to publish audio output {target_path} with {backend}: {error}", path=target_path, backend=backend
+        ) from error

--- a/audio_separator/separator/common_separator.py
+++ b/audio_separator/separator/common_separator.py
@@ -9,6 +9,8 @@ import librosa
 import torch
 from pydub import AudioSegment
 import soundfile as sf
+from audio_separator.separator.audio_io import atomic_output_path, validate_audio_source
+from audio_separator.separator.exceptions import AudioExportError, InvalidAudioDataError
 from audio_separator.separator.uvr_lib_v5 import spec_utils
 
 
@@ -264,12 +266,16 @@ class CommonSeparator:
 
         # If the original input was a filepath, check if the loaded mix is empty
         if isinstance(audio_path, str):
-            if not np.any(mix):
-                error_msg = f"Audio file {audio_path} is empty or not valid"
+            if mix.size == 0:
+                error_msg = f"Audio file {audio_path} contains no audio frames"
                 self.logger.error(error_msg)
-                raise ValueError(error_msg)
+                raise InvalidAudioDataError(error_msg)
+            elif not np.isfinite(mix).all():
+                error_msg = f"Audio file {audio_path} contains non-finite samples"
+                self.logger.error(error_msg)
+                raise InvalidAudioDataError(error_msg)
             else:
-                self.logger.debug("Audio file is valid and contains data.")
+                self.logger.debug("Audio file is valid and contains audio frames.")
 
         # Ensure the mix is in stereo format
         if mix.ndim == 1:
@@ -306,17 +312,16 @@ class CommonSeparator:
         """
         self.logger.debug(f"Entering write_audio_pydub with stem_path: {stem_path}")
 
+        stem_source = validate_audio_source(stem_source)
         stem_source = spec_utils.normalize(wave=stem_source, max_peak=self.normalization_threshold, min_peak=self.amplification_threshold)
-
-        # Check if the numpy array is empty or contains very low values
-        if np.max(np.abs(stem_source)) < 1e-6:
-            self.logger.warning("Warning: stem_source array is near-silent or empty.")
-            return
 
         # If output_dir is specified, create it and join it with stem_path
         if self.output_dir:
-            os.makedirs(self.output_dir, exist_ok=True)
             stem_path = os.path.join(self.output_dir, stem_path)
+            try:
+                os.makedirs(self.output_dir, exist_ok=True)
+            except Exception as e:
+                raise AudioExportError(f"Failed to prepare output directory for {stem_path}: {e}", path=stem_path, backend="pydub") from e
 
         self.logger.debug(f"Audio data shape before processing: {stem_source.shape}")
         self.logger.debug(f"Data type before conversion: {stem_source.dtype}")
@@ -331,20 +336,17 @@ class CommonSeparator:
             stem_source = (stem_source * 32767).astype(np.int16)
             self.logger.debug("Converted stem_source to int16 for pydub processing.")
 
-        # Correctly interleave stereo channels
-        stem_source_interleaved = np.empty((2 * stem_source.shape[0],), dtype=np.int16)
-        stem_source_interleaved[0::2] = stem_source[:, 0]  # Left channel
-        stem_source_interleaved[1::2] = stem_source[:, 1]  # Right channel
+        channels = 1 if stem_source.ndim == 1 else stem_source.shape[1]
+        stem_source_interleaved = np.ascontiguousarray(stem_source).reshape(-1)
 
         self.logger.debug(f"Interleaved audio data shape: {stem_source_interleaved.shape}")
 
         # Create a pydub AudioSegment (always from 16-bit data)
         try:
-            audio_segment = AudioSegment(stem_source_interleaved.tobytes(), frame_rate=self.sample_rate, sample_width=2, channels=2)
+            audio_segment = AudioSegment(stem_source_interleaved.tobytes(), frame_rate=self.sample_rate, sample_width=2, channels=channels)
             self.logger.debug("Created AudioSegment successfully.")
-        except (IOError, ValueError) as e:
-            self.logger.error(f"Specific error creating AudioSegment: {e}")
-            return
+        except Exception as e:
+            raise AudioExportError(f"Failed to create audio for {stem_path} with pydub: {e}", path=stem_path, backend="pydub") from e
 
         # Determine file format based on the file extension
         file_format = stem_path.lower().split(".")[-1]
@@ -358,8 +360,10 @@ class CommonSeparator:
         # Set the bitrate to 320k for mp3 files if output_bitrate is not specified
         bitrate = "320k" if file_format == "mp3" and self.output_bitrate is None else self.output_bitrate
 
+        target_path = stem_path
+
         # Export using the determined format
-        try:
+        with atomic_output_path(target_path, "pydub") as temp_path:
             # Pass codec parameters to ffmpeg to enforce bit depth for lossless formats
             export_params = {"format": file_format}
             
@@ -383,10 +387,11 @@ class CommonSeparator:
                     if file_format == "wav":
                         export_params["codec"] = "pcm_s32le"
             
-            audio_segment.export(stem_path, **export_params)
-            self.logger.debug(f"Exported audio file successfully to {stem_path} with {output_bit_depth}-bit depth")
-        except (IOError, ValueError) as e:
-            self.logger.error(f"Error exporting audio file: {e}")
+            export_handle = audio_segment.export(temp_path, **export_params)
+            close_export = getattr(export_handle, "close", None)
+            if callable(close_export):
+                close_export()
+        self.logger.debug(f"Exported audio file successfully to {target_path} with {output_bit_depth}-bit depth")
 
     def write_audio_soundfile(self, stem_path: str, stem_source):
         """
@@ -394,17 +399,16 @@ class CommonSeparator:
         """
         self.logger.debug(f"Entering write_audio_soundfile with stem_path: {stem_path}")
 
+        stem_source = validate_audio_source(stem_source)
         stem_source = spec_utils.normalize(wave=stem_source, max_peak=self.normalization_threshold, min_peak=self.amplification_threshold)
-
-        # Check if the numpy array is empty or contains very low values
-        if np.max(np.abs(stem_source)) < 1e-6:
-            self.logger.warning("Warning: stem_source array is near-silent or empty.")
-            return
 
         # If output_dir is specified, create it and join it with stem_path
         if self.output_dir:
-            os.makedirs(self.output_dir, exist_ok=True)
             stem_path = os.path.join(self.output_dir, stem_path)
+            try:
+                os.makedirs(self.output_dir, exist_ok=True)
+            except Exception as e:
+                raise AudioExportError(f"Failed to prepare output directory for {stem_path}: {e}", path=stem_path, backend="soundfile") from e
 
         # Determine the subtype based on the input audio's bit depth
         output_subtype = None
@@ -428,7 +432,7 @@ class CommonSeparator:
             self.logger.warning("No bit depth info available, defaulting to PCM_16")
 
         # Correctly interleave stereo channels if needed
-        if stem_source.shape[1] == 2:
+        if stem_source.ndim == 2 and stem_source.shape[1] == 2:
             # If the audio is already interleaved, ensure it's in the correct order
             # Check if the array is Fortran contiguous (column-major)
             if stem_source.flags["F_CONTIGUOUS"]:
@@ -442,13 +446,11 @@ class CommonSeparator:
         """
         Write audio using soundfile (for formats other than M4A).
         """
-        # Save audio using soundfile with the specified subtype
-        try:
+        target_path = stem_path
+        with atomic_output_path(target_path, "soundfile") as temp_path:
             # Specify the subtype to match input bit depth
-            sf.write(stem_path, stem_source, self.sample_rate, subtype=output_subtype)
-            self.logger.debug(f"Exported audio file successfully to {stem_path} with subtype {output_subtype}")
-        except Exception as e:
-            self.logger.error(f"Error exporting audio file: {e}")
+            sf.write(temp_path, stem_source, self.sample_rate, subtype=output_subtype)
+        self.logger.debug(f"Exported audio file successfully to {target_path} with subtype {output_subtype}")
 
     def clear_gpu_cache(self):
         """

--- a/audio_separator/separator/common_separator.py
+++ b/audio_separator/separator/common_separator.py
@@ -264,18 +264,17 @@ class CommonSeparator:
             mix = mix.T
             self.logger.debug(f"Transposed mix shape: {mix.shape}")
 
-        # If the original input was a filepath, check if the loaded mix is empty
-        if isinstance(audio_path, str):
-            if mix.size == 0:
-                error_msg = f"Audio file {audio_path} contains no audio frames"
-                self.logger.error(error_msg)
-                raise InvalidAudioDataError(error_msg)
-            elif not np.isfinite(mix).all():
-                error_msg = f"Audio file {audio_path} contains non-finite samples"
-                self.logger.error(error_msg)
-                raise InvalidAudioDataError(error_msg)
-            else:
-                self.logger.debug("Audio file is valid and contains audio frames.")
+        source_description = "Audio array" if isinstance(audio_path, np.ndarray) else f"Audio file {audio_path}"
+        if mix.size == 0:
+            error_msg = f"{source_description} contains no audio frames"
+            self.logger.error(error_msg)
+            raise InvalidAudioDataError(error_msg)
+        elif not np.isfinite(mix).all():
+            error_msg = f"{source_description} contains non-finite samples"
+            self.logger.error(error_msg)
+            raise InvalidAudioDataError(error_msg)
+        else:
+            self.logger.debug("Audio input is valid and contains audio frames.")
 
         # Ensure the mix is in stereo format
         if mix.ndim == 1:

--- a/audio_separator/separator/exceptions.py
+++ b/audio_separator/separator/exceptions.py
@@ -1,0 +1,29 @@
+"""Public exceptions raised by audio validation and separation output handling."""
+
+
+class InvalidAudioDataError(ValueError):
+    """Raised when decoded or generated audio data cannot be processed safely."""
+
+
+class AudioExportError(RuntimeError):
+    """Raised when an audio backend or filesystem cannot publish an output file."""
+
+    def __init__(self, message, *, path, backend):
+        super().__init__(message)
+        self.path = path
+        self.backend = backend
+
+
+class BatchSeparationError(RuntimeError):
+    """Raised after a batch finishes with failed inputs.
+
+    ``successful_files`` contains files from inputs that returned normally. A
+    fully published stem from an input that later failed is left on disk but is
+    intentionally excluded because that input did not complete its full stem set.
+    """
+
+    def __init__(self, successful_files, failures):
+        self.successful_files = list(successful_files)
+        self.failures = list(failures.items()) if isinstance(failures, dict) else list(failures)
+        failure_details = "; ".join(f"{path}: {error}" for path, error in self.failures)
+        super().__init__(f"Separation failed for {len(self.failures)} input(s): {failure_details}")

--- a/audio_separator/separator/separator.py
+++ b/audio_separator/separator/separator.py
@@ -23,7 +23,9 @@ import torch
 import torch.amp.autocast_mode as autocast_mode
 import onnxruntime as ort
 from tqdm import tqdm
+from audio_separator.separator.audio_io import atomic_output_path, validate_audio_source
 from audio_separator.separator.ensembler import Ensembler
+from audio_separator.separator.exceptions import AudioExportError, BatchSeparationError, InvalidAudioDataError
 
 # Mapping of common stem name variations to canonical names for ensemble grouping.
 STEM_NAME_MAP = {
@@ -47,6 +49,15 @@ STEM_NAME_MAP = {
     "primary stem": "Primary Stem",
     "secondary stem": "Secondary Stem",
 }
+
+SUPPORTED_AUDIO_EXTENSIONS = (".wav", ".flac", ".mp3", ".ogg", ".opus", ".m4a", ".aiff", ".ac3")
+
+
+def _iter_directory_audio_files(directory):
+    for root, _dirs, files in os.walk(directory):
+        for filename in files:
+            if filename.endswith(SUPPORTED_AUDIO_EXTENSIONS):
+                yield os.path.join(root, filename)
 
 
 class Separator:
@@ -953,14 +964,50 @@ class Separator:
         - custom_output_names (dict, optional): Custom names for the output files. Defaults to None.
 
         Returns:
-        - output_files (list of str): A list containing the paths to the separated audio stem files.
+        - output_files (list of str): Fully written output paths produced by inputs that completed
+          their full stem set. Valid silent and near-silent stems are included.
+
+        Raises:
+        - InvalidAudioDataError: Decoded or generated audio data was empty, non-finite, or structurally invalid.
+        - AudioExportError: An audio backend or filesystem failed to publish an output file.
+        - BatchSeparationError: A list or directory input had one or more failures. All discoverable
+          inputs are attempted first; inspect ``successful_files`` and the ordered ``failures`` list.
+
+        A single file fails immediately with its original exception. Import the public exception
+        types from ``audio_separator.separator``.
         """
         # Check if the model and device are properly initialized
         if not (self.torch_device and (self.model_instance or (isinstance(self.model_filename, list) and len(self.model_filename) > 0))):
             raise ValueError("Initialization failed or model not loaded. Please load a model before attempting to separate.")
 
         if isinstance(self.model_filename, list) and len(self.model_filename) > 1:
-            return self._separate_ensemble(audio_file_path, custom_output_names)
+            if isinstance(audio_file_path, str) and not os.path.isdir(audio_file_path):
+                return self._separate_ensemble(audio_file_path, custom_output_names)
+
+            ensemble_inputs = []
+            failures = []
+            input_paths = [audio_file_path] if isinstance(audio_file_path, str) else audio_file_path
+            for path in input_paths:
+                if os.path.isdir(path):
+                    ensemble_inputs.extend(_iter_directory_audio_files(path))
+                else:
+                    ensemble_inputs.append(path)
+
+            output_files = []
+            for path in ensemble_inputs:
+                try:
+                    output_files.extend(self._separate_ensemble(path, custom_output_names))
+                except Exception as e:
+                    self.logger.error(f"Failed to process ensemble file {path}: {e}", exc_info=True)
+                    failures.append((path, e))
+
+            if failures:
+                raise BatchSeparationError(output_files, failures)
+            return output_files
+
+        if isinstance(audio_file_path, str) and not os.path.isdir(audio_file_path):
+            self.logger.info(f"Processing file: {audio_file_path}")
+            return self._separate_file(audio_file_path, custom_output_names)
 
         # If audio_file_path is a string, convert it to a list for uniform processing
         if isinstance(audio_file_path, str):
@@ -968,23 +1015,21 @@ class Separator:
 
         # Initialize a list to store paths of all output files
         output_files = []
+        failures = []
 
         # Process each path in the list
         for path in audio_file_path:
             if os.path.isdir(path):
                 # If the path is a directory, recursively search for all audio files
-                for root, dirs, files in os.walk(path):
-                    for file in files:
-                        # Check the file extension to ensure it's an audio file
-                        if file.endswith((".wav", ".flac", ".mp3", ".ogg", ".opus", ".m4a", ".aiff", ".ac3")):  # Add other formats if needed
-                            full_path = os.path.join(root, file)
-                            self.logger.info(f"Processing file: {full_path}")
-                            try:
-                                # Perform separation for each file
-                                files_output = self._separate_file(full_path, custom_output_names)
-                                output_files.extend(files_output)
-                            except Exception as e:
-                                self.logger.error(f"Failed to process file {full_path}: {e}", exc_info=True)
+                for full_path in _iter_directory_audio_files(path):
+                    self.logger.info(f"Processing file: {full_path}")
+                    try:
+                        # Perform separation for each file
+                        files_output = self._separate_file(full_path, custom_output_names)
+                        output_files.extend(files_output)
+                    except Exception as e:
+                        self.logger.error(f"Failed to process file {full_path}: {e}", exc_info=True)
+                        failures.append((full_path, e))
             else:
                 # If the path is a file, process it directly
                 self.logger.info(f"Processing file: {path}")
@@ -993,7 +1038,10 @@ class Separator:
                     output_files.extend(files_output)
                 except Exception as e:
                     self.logger.error(f"Failed to process file {path}: {e}", exc_info=True)
+                    failures.append((path, e))
 
+        if failures:
+            raise BatchSeparationError(output_files, failures)
         return output_files
 
     def _separate_file(self, audio_file_path, custom_output_names=None):
@@ -1027,21 +1075,37 @@ class Separator:
         self.logger.debug(f"Normalization threshold set to {self.normalization_threshold}, waveform will be lowered to this max amplitude to avoid clipping.")
         self.logger.debug(f"Amplification threshold set to {self.amplification_threshold}, waveform will be scaled up to this max amplitude if below it.")
 
-        # Run separation method for the loaded model with autocast enabled if supported by the device
-        output_files = None
-        if self.use_autocast and autocast_mode.is_autocast_available(self.torch_device.type):
-            self.logger.debug("Autocast available.")
-            with autocast_mode.autocast(self.torch_device.type):
+        try:
+            # Run separation method for the loaded model with autocast enabled if supported by the device
+            output_files = None
+            if self.use_autocast and autocast_mode.is_autocast_available(self.torch_device.type):
+                self.logger.debug("Autocast available.")
+                with autocast_mode.autocast(self.torch_device.type):
+                    output_files = self.model_instance.separate(audio_file_path, custom_output_names)
+            else:
+                self.logger.debug("Autocast unavailable.")
                 output_files = self.model_instance.separate(audio_file_path, custom_output_names)
-        else:
-            self.logger.debug("Autocast unavailable.")
-            output_files = self.model_instance.separate(audio_file_path, custom_output_names)
+        finally:
+            # Clear per-file state even when inference or audio export fails.
+            active_error = sys.exc_info()[1]
+            cleanup_errors = []
+            for cleanup_name in ("clear_gpu_cache", "clear_file_specific_paths"):
+                try:
+                    getattr(self.model_instance, cleanup_name)()
+                except Exception as cleanup_error:
+                    cleanup_errors.append((cleanup_name, cleanup_error))
+                    self.logger.error(f"Cleanup step {cleanup_name} failed: {cleanup_error}", exc_info=True)
 
-        # Clear GPU cache to free up memory
-        self.model_instance.clear_gpu_cache()
-
-        # Unset separation parameters to prevent accidentally re-using the wrong source files or output paths
-        self.model_instance.clear_file_specific_paths()
+            if cleanup_errors:
+                if active_error is not None:
+                    if hasattr(active_error, "add_note"):
+                        for cleanup_name, cleanup_error in cleanup_errors:
+                            active_error.add_note(f"Cleanup step {cleanup_name} failed: {cleanup_error}")
+                else:
+                    cleanup_name, cleanup_error = cleanup_errors[0]
+                    if hasattr(cleanup_error, "add_note"):
+                        cleanup_error.add_note(f"Cleanup step failed: {cleanup_name}")
+                    raise cleanup_error
 
         # Remind the user one more time if they used a VIP model, so the message doesn't get lost in the logs
         self.print_uvr_vip_message()
@@ -1082,6 +1146,7 @@ class Separator:
 
             # Process each chunk
             processed_chunks_by_stem = {}
+            stem_names_by_chunk = []
 
             for i, chunk_path in enumerate(chunk_paths):
                 self.logger.info(f"Processing chunk {i+1}/{len(chunk_paths)}: {chunk_path}")
@@ -1097,9 +1162,10 @@ class Separator:
 
                 try:
                     output_files = self._separate_file(chunk_path)
+                    current_stem_names = set()
 
                     # Dynamically group chunks by stem name
-                    for stem_path in output_files:
+                    for stem_index, stem_path in enumerate(output_files):
                         # Extract stem name from filename: "chunk_0000_(Vocals).wav" → "Vocals"
                         filename = os.path.basename(stem_path)
                         match = re.search(r'_\(([^)]+)\)', filename)
@@ -1107,10 +1173,12 @@ class Separator:
                             stem_name = match.group(1)
                         else:
                             # Fallback: use index-based name if pattern not found
-                            stem_index = len([k for k in processed_chunks_by_stem.keys() if k.startswith('stem_')])
                             stem_name = f"stem_{stem_index}"
                             self.logger.warning(f"Could not extract stem name from {filename}, using {stem_name}")
 
+                        if stem_name in current_stem_names:
+                            raise InvalidAudioDataError(f"Chunk {i} produced duplicate stem output: {stem_name}")
+                        current_stem_names.add(stem_name)
                         if stem_name not in processed_chunks_by_stem:
                             processed_chunks_by_stem[stem_name] = []
 
@@ -1120,6 +1188,7 @@ class Separator:
 
                     if not output_files:
                         self.logger.warning(f"Chunk {i+1} produced no output files")
+                    stem_names_by_chunk.append(current_stem_names)
 
                 finally:
                     self.chunk_duration = original_chunk_duration
@@ -1130,6 +1199,19 @@ class Separator:
                 # Clear GPU cache between chunks
                 if self.model_instance:
                     self.model_instance.clear_gpu_cache()
+
+            all_stem_names = set().union(*stem_names_by_chunk) if stem_names_by_chunk else set()
+            if not all_stem_names:
+                raise InvalidAudioDataError("Chunked separation produced no stems")
+
+            missing_stems = {
+                chunk_index: sorted(all_stem_names - chunk_stems)
+                for chunk_index, chunk_stems in enumerate(stem_names_by_chunk)
+                if chunk_stems != all_stem_names
+            }
+            if missing_stems:
+                details = "; ".join(f"chunk {chunk_index}: {', '.join(stems)}" for chunk_index, stems in missing_stems.items())
+                raise InvalidAudioDataError(f"Chunked separation is missing stem output(s): {details}")
 
             # Merge chunks for each stem dynamically
             base_name = os.path.splitext(os.path.basename(audio_file_path))[0]
@@ -1393,14 +1475,25 @@ class Separator:
                         final_output_path = os.path.join(self.output_dir, output_path)
 
                         import soundfile as sf
+                        from audio_separator.separator.uvr_lib_v5 import spec_utils
 
+                        ensemble_audio = validate_audio_source(ensembled_wav.T)
+                        ensemble_audio = spec_utils.normalize(
+                            wave=ensemble_audio,
+                            max_peak=self.normalization_threshold,
+                            min_peak=self.amplification_threshold,
+                        )
                         try:
-                            self.logger.debug(f"Attempting to write ensembled audio to {final_output_path}...")
-                            sf.write(final_output_path, ensembled_wav.T, self.sample_rate)
-                        except Exception as e:
-                            self.logger.error(f"Error writing {self.output_format} format: {e}. Falling back to WAV.")
+                            with atomic_output_path(final_output_path, "soundfile") as temp_output_path:
+                                self.logger.debug(f"Attempting to write ensembled audio to {final_output_path}...")
+                                sf.write(temp_output_path, ensemble_audio, self.sample_rate)
+                        except AudioExportError as requested_format_error:
+                            self.logger.error(
+                                f"Error writing {self.output_format} format: {requested_format_error}. Falling back to WAV."
+                            )
                             final_output_path = final_output_path.rsplit(".", 1)[0] + ".wav"
-                            sf.write(final_output_path, ensembled_wav.T, self.sample_rate)
+                            with atomic_output_path(final_output_path, "soundfile") as temp_output_path:
+                                sf.write(temp_output_path, ensemble_audio, self.sample_rate)
 
                         output_files.append(final_output_path)
 

--- a/audio_separator/separator/separator.py
+++ b/audio_separator/separator/separator.py
@@ -56,7 +56,7 @@ SUPPORTED_AUDIO_EXTENSIONS = (".wav", ".flac", ".mp3", ".ogg", ".opus", ".m4a", 
 def _iter_directory_audio_files(directory):
     for root, _dirs, files in os.walk(directory):
         for filename in files:
-            if filename.endswith(SUPPORTED_AUDIO_EXTENSIONS):
+            if filename.lower().endswith(SUPPORTED_AUDIO_EXTENSIONS):
                 yield os.path.join(root, filename)
 
 

--- a/audio_separator/separator/uvr_lib_v5/spec_utils.py
+++ b/audio_separator/separator/uvr_lib_v5/spec_utils.py
@@ -5,6 +5,7 @@ import soundfile as sf
 import math
 import platform
 import traceback
+from audio_separator.separator.exceptions import InvalidAudioDataError
 from audio_separator.separator.uvr_lib_v5 import pyrb
 from scipy.signal import correlate, hilbert
 import io
@@ -106,10 +107,17 @@ def normalize(wave, max_peak=1.0, min_peak=None):
     Returns:
         array-like: Normalized or original waveform.
     """
+    wave = np.asarray(wave)
+    if wave.size == 0:
+        raise InvalidAudioDataError("Audio data is empty")
+
     maxv = np.abs(wave).max()
+    if not np.isfinite(maxv):
+        raise InvalidAudioDataError("Audio data must contain only finite values")
+
     if maxv > max_peak:
         wave *= max_peak / maxv
-    elif min_peak is not None and maxv < min_peak:
+    elif min_peak is not None and 0 < maxv < min_peak:
         wave *= min_peak / maxv
 
     return wave

--- a/audio_separator/utils/cli.py
+++ b/audio_separator/utils/cli.py
@@ -295,13 +295,13 @@ def main():
             model_filenames = model_filenames[0]
         separator.load_model(model_filename=model_filenames)
 
-    output_files = separator.separate(audio_files, custom_output_names=args.custom_output_names)
+    try:
+        output_files = separator.separate(audio_files, custom_output_names=args.custom_output_names)
+    except Exception as e:
+        logger.error(f"Separation failed: {e}", exc_info=True)
+        sys.exit(1)
 
     if not output_files:
-        # Separator.separate logs and swallows per-file errors so a batch can
-        # continue past one bad file — but if NOTHING was produced, the run
-        # failed and the CLI must not report success (this previously exited 0
-        # with "Separation complete!" after logging an error).
         logger.error("Separation produced no output files — see errors above.")
         sys.exit(1)
 

--- a/tests/unit/test_architecture_output_contract.py
+++ b/tests/unit/test_architecture_output_contract.py
@@ -1,0 +1,67 @@
+"""Architecture-level contracts for propagating final audio writer failures."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from audio_separator.separator.architectures.mdx_separator import MDXSeparator
+from audio_separator.separator.architectures.mdxc_separator import MDXCSeparator
+from audio_separator.separator.exceptions import AudioExportError
+
+
+def architecture_double(separator_class):
+    separator = Mock(spec=separator_class)
+    separator.logger = logging.getLogger(__name__)
+    separator.normalization_threshold = 0.9
+    separator.amplification_threshold = 0.0
+    separator.output_single_stem = None
+    return separator
+
+
+def test_mdx_does_not_return_planned_path_when_final_writer_fails():
+    separator = architecture_double(MDXSeparator)
+    separator.prepare_mix.return_value = np.zeros((2, 32), dtype=np.float32)
+    separator.demix.side_effect = [np.zeros((2, 32), dtype=np.float32), np.zeros((2, 32), dtype=np.float32)]
+    separator.primary_source = None
+    separator.secondary_source = None
+    separator.primary_stem_name = "Vocals"
+    separator.secondary_stem_name = "Instrumental"
+    separator.compensate = 1.0
+    separator.invert_using_spec = False
+    separator.get_stem_output_path.side_effect = ["input_(Instrumental).wav", "input_(Vocals).wav"]
+    writer_error = AudioExportError("writer failed", path="input_(Instrumental).wav", backend="pydub")
+    separator.final_process.side_effect = writer_error
+
+    with pytest.raises(AudioExportError) as raised:
+        MDXSeparator.separate(separator, "input.wav")
+
+    assert raised.value is writer_error
+
+
+def test_mdxc_multistem_does_not_return_planned_path_when_final_writer_fails():
+    separator = architecture_double(MDXCSeparator)
+    separator.prepare_mix.return_value = np.zeros((2, 32), dtype=np.float32)
+    separator.sample_rate = 44100
+    separator.override_model_segment_size = True
+    separator.process_all_stems = True
+    separator.primary_source = None
+    separator.secondary_source = None
+    separator.model_data_cfgdict = SimpleNamespace(
+        training=SimpleNamespace(target_instrument=None, instruments=["Vocals", "Drums", "Bass"])
+    )
+    separator.demix.return_value = {
+        "Vocals": np.zeros((2, 32), dtype=np.float32),
+        "Drums": np.zeros((2, 32), dtype=np.float32),
+        "Bass": np.zeros((2, 32), dtype=np.float32),
+    }
+    separator.get_stem_output_path.return_value = "input_(Vocals).wav"
+    writer_error = AudioExportError("writer failed", path="input_(Vocals).wav", backend="soundfile")
+    separator.final_process.side_effect = writer_error
+
+    with pytest.raises(AudioExportError) as raised:
+        MDXCSeparator.separate(separator, "input.wav")
+
+    assert raised.value is writer_error

--- a/tests/unit/test_audio_chunking.py
+++ b/tests/unit/test_audio_chunking.py
@@ -7,10 +7,13 @@ import pytest
 import os
 import tempfile
 import logging
+from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 from pydub import AudioSegment
+from pydub.generators import Sine
 
 from audio_separator.separator.audio_chunking import AudioChunker
+from audio_separator.separator.exceptions import AudioExportError
 
 
 class TestAudioChunker:
@@ -121,7 +124,7 @@ class TestAudioChunker:
         mock_chunk1 = Mock()
         mock_chunk2 = Mock()
         mock_combined = Mock()
-        mock_combined.export = Mock()
+        mock_combined.export = Mock(side_effect=lambda path, **_kwargs: Path(path).write_bytes(b"audio"))
 
         # Setup mock to return chunks and allow addition
         mock_from_file.side_effect = [mock_chunk1, mock_chunk2]
@@ -226,6 +229,51 @@ class TestAudioChunkerIntegration:
             if os.path.exists(temp_dir):
                 shutil.rmtree(temp_dir)
 
+    def test_merge_failure_preserves_existing_target_and_removes_partial_file(self, tmp_path):
+        chunk_path = tmp_path / "chunk.wav"
+        AudioSegment.silent(duration=10).export(chunk_path, format="wav")
+        output_path = tmp_path / "merged.wav"
+        output_path.write_bytes(b"original")
+
+        def export_partial_then_fail(path, **_kwargs):
+            Path(path).write_bytes(b"partial")
+            raise OSError("ffmpeg failed")
+
+        with patch.object(AudioSegment, "export", side_effect=export_partial_then_fail):
+            with pytest.raises(AudioExportError):
+                AudioChunker(5.0).merge_chunks([str(chunk_path)], str(output_path))
+
+        assert output_path.read_bytes() == b"original"
+        assert sorted(path.name for path in tmp_path.iterdir()) == ["chunk.wav", "merged.wav"]
+
+    def test_merge_closes_pydub_export_handle_before_replace(self, tmp_path):
+        chunk_path = tmp_path / "chunk.wav"
+        AudioSegment.silent(duration=10).export(chunk_path, format="wav")
+        export_handle = Mock()
+
+        def export_audio(path, **_kwargs):
+            Path(path).write_bytes(b"encoded audio")
+            return export_handle
+
+        with patch.object(AudioSegment, "export", side_effect=export_audio):
+            AudioChunker(5.0).merge_chunks([str(chunk_path)], str(tmp_path / "merged.wav"))
+
+        export_handle.close.assert_called_once_with()
+
+    def test_merge_preserves_duration_of_a_silent_intermediate_chunk(self, tmp_path):
+        chunks = [Sine(440).to_audio_segment(duration=100), AudioSegment.silent(duration=150), Sine(440).to_audio_segment(duration=200)]
+        chunk_paths = []
+        for index, chunk in enumerate(chunks):
+            chunk_path = tmp_path / f"chunk-{index}.wav"
+            chunk.export(chunk_path, format="wav")
+            chunk_paths.append(str(chunk_path))
+
+        output_path = tmp_path / "merged.wav"
+        AudioChunker(5.0).merge_chunks(chunk_paths, str(output_path))
+
+        decoded = AudioSegment.from_file(output_path)
+        assert abs(len(decoded) - 450) <= 2
+        assert decoded[110:240].rms == 0
 
 class TestAudioChunkerEdgeCases:
     """Test edge cases and error handling."""

--- a/tests/unit/test_audio_output_contract.py
+++ b/tests/unit/test_audio_output_contract.py
@@ -1,0 +1,303 @@
+"""Contract tests for validating and exporting separated audio."""
+
+import importlib
+import os
+from pathlib import Path
+import shutil
+import stat
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+from pydub import AudioSegment
+
+from audio_separator.separator.audio_io import validate_audio_source
+from audio_separator.separator.architectures.demucs_separator import DemucsSeparator
+from audio_separator.separator.common_separator import CommonSeparator
+from audio_separator.separator.uvr_lib_v5 import spec_utils
+from audio_separator.separator.exceptions import AudioExportError, BatchSeparationError, InvalidAudioDataError
+
+
+@pytest.fixture
+def common_separator(tmp_path):
+    config = {
+        "logger": Mock(),
+        "log_level": 20,
+        "torch_device": Mock(),
+        "torch_device_cpu": Mock(),
+        "torch_device_mps": Mock(),
+        "onnx_execution_provider": Mock(),
+        "model_name": "test_model",
+        "model_path": "/path/to/model",
+        "model_data": {"training": {"instruments": ["vocals", "other"]}},
+        "output_dir": str(tmp_path),
+        "output_format": "wav",
+        "output_bitrate": None,
+        "normalization_threshold": 0.9,
+        "amplification_threshold": 0.1,
+        "enable_denoise": False,
+        "output_single_stem": None,
+        "invert_using_spec": False,
+        "sample_rate": 44100,
+        "use_soundfile": True,
+    }
+    return CommonSeparator(config)
+
+
+def test_normalize_preserves_silence_when_amplification_is_enabled():
+    wave = np.zeros((16, 2), dtype=np.float32)
+
+    normalized = spec_utils.normalize(wave, max_peak=0.9, min_peak=0.1)
+
+    np.testing.assert_array_equal(normalized, wave)
+    assert np.isfinite(normalized).all()
+
+
+@pytest.mark.parametrize(
+    ("wave", "message"),
+    [
+        (np.array([], dtype=np.float32), "empty"),
+        (np.array([0.0, np.nan], dtype=np.float32), "finite"),
+        (np.array([-np.inf, np.inf], dtype=np.float32), "finite"),
+    ],
+)
+def test_normalize_rejects_invalid_audio(wave, message):
+    with pytest.raises(InvalidAudioDataError, match=message):
+        spec_utils.normalize(wave)
+
+
+def test_soundfile_writer_exports_silent_stereo_audio(common_separator, tmp_path):
+    frames = 441
+
+    common_separator.write_audio_soundfile("silent.wav", np.zeros((frames, 2), dtype=np.float32))
+
+    output_path = tmp_path / "silent.wav"
+    info = sf.info(output_path)
+    assert output_path.stat().st_size > 0
+    assert info.frames == frames
+    assert info.channels == 2
+    assert info.samplerate == common_separator.sample_rate
+
+
+def test_prepare_mix_accepts_nonempty_silent_audio(common_separator, tmp_path):
+    frames = 441
+    input_path = tmp_path / "silent-input.wav"
+    sf.write(input_path, np.zeros((frames, 2), dtype=np.float32), common_separator.sample_rate)
+
+    mix = common_separator.prepare_mix(str(input_path))
+
+    assert mix.shape == (2, frames)
+    assert np.isfinite(mix).all()
+    assert np.count_nonzero(mix) == 0
+
+
+def test_demucs_receives_finite_normalized_silent_audio():
+    separator = Mock(spec=DemucsSeparator)
+    separator.logger = Mock()
+    separator.demucs_model_instance = Mock()
+    separator.demucs_model_instance.sources = ["drums", "bass", "other", "vocals"]
+    separator.demucs_model_instance.models = []
+    separator.shifts = 0
+    separator.segments_enabled = True
+    separator.overlap = 0.25
+    separator.torch_device = torch.device("cpu")
+
+    def apply_silent_model(*, mix, **_kwargs):
+        assert torch.isfinite(mix).all()
+        return torch.zeros((1, 4, 2, mix.shape[-1]), dtype=torch.float32)
+
+    with patch("audio_separator.separator.architectures.demucs_separator.apply_model", side_effect=apply_silent_model):
+        sources = DemucsSeparator.demix_demucs(separator, np.zeros((2, 32), dtype=np.float32))
+
+    assert np.isfinite(sources).all()
+
+
+def test_pydub_writer_exports_silent_stereo_audio(common_separator, tmp_path):
+    frames = 441
+
+    common_separator.write_audio_pydub("silent-pydub.wav", np.zeros((frames, 2), dtype=np.float32))
+
+    output_path = tmp_path / "silent-pydub.wav"
+    info = sf.info(output_path)
+    assert output_path.stat().st_size > 0
+    assert info.frames == frames
+    assert info.channels == 2
+    assert info.samplerate == common_separator.sample_rate
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="FFmpeg is required for M4A encoding")
+def test_pydub_writer_exports_redecodable_near_silent_m4a(common_separator, tmp_path):
+    frames = 4410
+    common_separator.amplification_threshold = 0.0
+    near_silent = np.full((frames, 2), 5e-7, dtype=np.float32)
+
+    common_separator.write_audio_pydub("near-silent.m4a", near_silent)
+
+    output_path = tmp_path / "near-silent.m4a"
+    decoded = AudioSegment.from_file(output_path)
+    assert output_path.stat().st_size > 0
+    assert decoded.channels == 2
+    assert abs(len(decoded) - 100) <= 30
+
+
+def test_pydub_writer_preserves_mono_audio(common_separator, tmp_path):
+    frames = 441
+
+    common_separator.write_audio_pydub("mono.wav", np.zeros(frames, dtype=np.float32))
+
+    info = sf.info(tmp_path / "mono.wav")
+    assert info.frames == frames
+    assert info.channels == 1
+
+
+def test_audio_source_validation_rejects_invalid_channel_shape():
+    with pytest.raises(InvalidAudioDataError, match="shape"):
+        validate_audio_source(np.zeros((32, 3), dtype=np.float32))
+
+
+def test_soundfile_failure_raises_audio_export_error_with_context(common_separator, tmp_path):
+    backend_error = OSError("disk full")
+
+    with patch("audio_separator.separator.common_separator.sf.write", side_effect=backend_error):
+        with pytest.raises(AudioExportError) as raised:
+            common_separator.write_audio_soundfile("broken.wav", np.zeros((32, 2), dtype=np.float32))
+
+    assert raised.value.path == str(tmp_path / "broken.wav")
+    assert raised.value.backend == "soundfile"
+    assert raised.value.__cause__ is backend_error
+
+
+def test_soundfile_failure_preserves_existing_target_and_removes_partial_file(common_separator, tmp_path):
+    output_path = tmp_path / "existing.wav"
+    output_path.write_bytes(b"original")
+
+    def write_partial_then_fail(path, *_args, **_kwargs):
+        Path(path).write_bytes(b"partial")
+        raise OSError("disk full")
+
+    with patch("audio_separator.separator.common_separator.sf.write", side_effect=write_partial_then_fail):
+        with pytest.raises(AudioExportError):
+            common_separator.write_audio_soundfile(output_path.name, np.zeros((32, 2), dtype=np.float32))
+
+    assert output_path.read_bytes() == b"original"
+    assert list(tmp_path.iterdir()) == [output_path]
+
+
+def test_pydub_failure_raises_audio_export_error_with_context(common_separator, tmp_path):
+    backend_error = OSError("ffmpeg failed")
+
+    with patch.object(AudioSegment, "export", side_effect=backend_error):
+        with pytest.raises(AudioExportError) as raised:
+            common_separator.write_audio_pydub("broken-pydub.wav", np.zeros((32, 2), dtype=np.float32))
+
+    assert raised.value.path == str(tmp_path / "broken-pydub.wav")
+    assert raised.value.backend == "pydub"
+    assert raised.value.__cause__ is backend_error
+
+
+def test_pydub_export_handle_is_closed_before_publishing(common_separator):
+    export_handle = Mock()
+
+    def export_audio(path, **_kwargs):
+        Path(path).write_bytes(b"encoded audio")
+        return export_handle
+
+    with patch.object(AudioSegment, "export", side_effect=export_audio):
+        common_separator.write_audio_pydub("closed-handle.wav", np.zeros((32, 2), dtype=np.float32))
+
+    export_handle.close.assert_called_once_with()
+
+
+def test_pydub_constructor_failure_raises_audio_export_error(common_separator, tmp_path):
+    backend_error = ValueError("invalid raw audio")
+
+    with patch("audio_separator.separator.common_separator.AudioSegment", side_effect=backend_error):
+        with pytest.raises(AudioExportError) as raised:
+            common_separator.write_audio_pydub("constructor.wav", np.zeros((32, 2), dtype=np.float32))
+
+    assert raised.value.path == str(tmp_path / "constructor.wav")
+    assert raised.value.backend == "pydub"
+    assert raised.value.__cause__ is backend_error
+
+
+def test_soundfile_directory_failure_raises_audio_export_error(common_separator, tmp_path):
+    filesystem_error = OSError("permission denied")
+
+    with patch("audio_separator.separator.common_separator.os.makedirs", side_effect=filesystem_error):
+        with pytest.raises(AudioExportError) as raised:
+            common_separator.write_audio_soundfile("directory.wav", np.zeros((32, 2), dtype=np.float32))
+
+    assert raised.value.path == str(tmp_path / "directory.wav")
+    assert raised.value.backend == "soundfile"
+    assert raised.value.__cause__ is filesystem_error
+
+
+def test_temporary_file_failure_raises_audio_export_error(common_separator, tmp_path):
+    filesystem_error = OSError("too many open files")
+
+    with patch("audio_separator.separator.audio_io.tempfile.mkstemp", side_effect=filesystem_error):
+        with pytest.raises(AudioExportError) as raised:
+            common_separator.write_audio_soundfile("temporary.wav", np.zeros((32, 2), dtype=np.float32))
+
+    assert raised.value.path == str(tmp_path / "temporary.wav")
+    assert raised.value.backend == "soundfile"
+    assert raised.value.__cause__ is filesystem_error
+
+
+def test_atomic_replace_failure_preserves_target_and_removes_temporary_file(common_separator, tmp_path):
+    output_path = tmp_path / "replace.wav"
+    output_path.write_bytes(b"original")
+    filesystem_error = OSError("replace failed")
+
+    with patch("audio_separator.separator.audio_io.os.replace", side_effect=filesystem_error):
+        with pytest.raises(AudioExportError) as raised:
+            common_separator.write_audio_soundfile(output_path.name, np.zeros((32, 2), dtype=np.float32))
+
+    assert raised.value.path == str(output_path)
+    assert raised.value.backend == "soundfile"
+    assert raised.value.__cause__ is filesystem_error
+    assert output_path.read_bytes() == b"original"
+    assert list(tmp_path.iterdir()) == [output_path]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not available on Windows")
+def test_atomic_publish_preserves_existing_target_mode(common_separator, tmp_path):
+    output_path = tmp_path / "existing-mode.wav"
+    output_path.write_bytes(b"original")
+    output_path.chmod(0o640)
+
+    common_separator.write_audio_soundfile(output_path.name, np.zeros((32, 2), dtype=np.float32))
+
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o640
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not available on Windows")
+def test_atomic_publish_applies_umask_to_new_target(common_separator, tmp_path):
+    previous_umask = os.umask(0o027)
+    try:
+        common_separator.write_audio_soundfile("new-mode.wav", np.zeros((32, 2), dtype=np.float32))
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE((tmp_path / "new-mode.wav").stat().st_mode) == 0o640
+
+
+def test_zero_byte_backend_output_is_rejected_and_removed(common_separator, tmp_path):
+    with patch("audio_separator.separator.common_separator.sf.write", return_value=None):
+        with pytest.raises(AudioExportError, match="empty output"):
+            common_separator.write_audio_soundfile("zero-byte.wav", np.zeros((32, 2), dtype=np.float32))
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_audio_output_errors_are_exported_from_separator_package_only():
+    package = importlib.import_module("audio_separator.separator")
+
+    assert package.InvalidAudioDataError is InvalidAudioDataError
+    assert package.AudioExportError is AudioExportError
+    assert package.BatchSeparationError is BatchSeparationError
+    assert issubclass(package.InvalidAudioDataError, ValueError)
+    assert issubclass(package.AudioExportError, RuntimeError)
+    assert issubclass(package.BatchSeparationError, RuntimeError)

--- a/tests/unit/test_audio_output_contract.py
+++ b/tests/unit/test_audio_output_contract.py
@@ -20,6 +20,9 @@ from audio_separator.separator.uvr_lib_v5 import spec_utils
 from audio_separator.separator.exceptions import AudioExportError, BatchSeparationError, InvalidAudioDataError
 
 
+requires_ffmpeg = pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="FFmpeg is required for pydub encoding")
+
+
 @pytest.fixture
 def common_separator(tmp_path):
     config = {
@@ -93,6 +96,29 @@ def test_prepare_mix_accepts_nonempty_silent_audio(common_separator, tmp_path):
     assert np.count_nonzero(mix) == 0
 
 
+@pytest.mark.parametrize(
+    ("audio", "message"),
+    [
+        (np.empty((0, 2), dtype=np.float32), "no audio frames"),
+        (np.array([[0.0, np.nan]], dtype=np.float32), "non-finite samples"),
+        (np.array([[np.inf, 0.0]], dtype=np.float32), "non-finite samples"),
+    ],
+)
+def test_prepare_mix_rejects_invalid_numpy_audio(common_separator, audio, message):
+    with pytest.raises(InvalidAudioDataError, match=message):
+        common_separator.prepare_mix(audio)
+
+
+def test_prepare_mix_accepts_nonempty_silent_numpy_audio(common_separator):
+    frames = 32
+
+    mix = common_separator.prepare_mix(np.zeros((frames, 2), dtype=np.float32))
+
+    assert mix.shape == (2, frames)
+    assert np.isfinite(mix).all()
+    assert np.count_nonzero(mix) == 0
+
+
 def test_demucs_receives_finite_normalized_silent_audio():
     separator = Mock(spec=DemucsSeparator)
     separator.logger = Mock()
@@ -114,6 +140,7 @@ def test_demucs_receives_finite_normalized_silent_audio():
     assert np.isfinite(sources).all()
 
 
+@requires_ffmpeg
 def test_pydub_writer_exports_silent_stereo_audio(common_separator, tmp_path):
     frames = 441
 
@@ -127,7 +154,7 @@ def test_pydub_writer_exports_silent_stereo_audio(common_separator, tmp_path):
     assert info.samplerate == common_separator.sample_rate
 
 
-@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="FFmpeg is required for M4A encoding")
+@requires_ffmpeg
 def test_pydub_writer_exports_redecodable_near_silent_m4a(common_separator, tmp_path):
     frames = 4410
     common_separator.amplification_threshold = 0.0
@@ -142,6 +169,7 @@ def test_pydub_writer_exports_redecodable_near_silent_m4a(common_separator, tmp_
     assert abs(len(decoded) - 100) <= 30
 
 
+@requires_ffmpeg
 def test_pydub_writer_preserves_mono_audio(common_separator, tmp_path):
     frames = 441
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,6 +7,8 @@ import importlib.metadata
 from unittest import mock
 from unittest.mock import patch, MagicMock, mock_open
 
+from audio_separator.separator.exceptions import AudioExportError
+
 
 # Mock metadata.distribution for tests to avoid PackageNotFoundError in environment without installed package
 @pytest.fixture(autouse=True)
@@ -94,6 +96,19 @@ def test_cli_multiple_filenames():
         log_messages = [call[0][0] for call in mock_logger.info.call_args_list]
         assert any("test1.mp3" in msg and "test2.mp3" in msg for msg in log_messages)
         assert any("Separation complete" in msg for msg in log_messages)
+
+
+def test_cli_exits_one_when_audio_export_fails():
+    test_args = ["cli.py", "bad.wav"]
+    export_error = AudioExportError("writer failed", path="bad_(Vocals).flac", backend="pydub")
+
+    with patch("sys.argv", test_args), patch("audio_separator.separator.Separator") as separator_class:
+        separator_class.return_value.separate.side_effect = export_error
+
+        with pytest.raises(SystemExit) as raised:
+            main()
+
+    assert raised.value.code == 1
 
 
 # Test the CLI with a specific audio file

--- a/tests/unit/test_separation_error_contract.py
+++ b/tests/unit/test_separation_error_contract.py
@@ -1,6 +1,7 @@
 """Public separation error propagation and batch aggregation contracts."""
 
 import logging
+import os
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -58,8 +59,20 @@ def test_directory_processes_accessible_files_before_raising_batch_error():
             Separator.separate(separator, "/music")
 
     assert raised.value.successful_files == ["good_(Vocals).wav"]
-    assert raised.value.failures == [("/music/bad.wav", export_error)]
+    assert raised.value.failures == [(os.path.join("/music", "bad.wav"), export_error)]
     assert separator._separate_file.call_count == 2
+
+
+def test_directory_processes_uppercase_audio_extensions(tmp_path):
+    separator = separator_double()
+    track_path = tmp_path / "TRACK.MP3"
+    track_path.touch()
+    separator._separate_file.return_value = ["TRACK_(Vocals).wav"]
+
+    output_files = Separator.separate(separator, str(tmp_path))
+
+    assert output_files == ["TRACK_(Vocals).wav"]
+    separator._separate_file.assert_called_once_with(str(track_path), None)
 
 
 def test_cleanup_failures_do_not_mask_writer_error_or_skip_later_cleanup():

--- a/tests/unit/test_separation_error_contract.py
+++ b/tests/unit/test_separation_error_contract.py
@@ -1,0 +1,194 @@
+"""Public separation error propagation and batch aggregation contracts."""
+
+import logging
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+
+from audio_separator.separator.exceptions import AudioExportError, BatchSeparationError, InvalidAudioDataError
+from audio_separator.separator.separator import Separator
+
+
+def separator_double():
+    separator = Mock(spec=Separator)
+    separator.torch_device = Mock()
+    separator.model_instance = Mock()
+    separator.model_filename = "model.ckpt"
+    separator.logger = logging.getLogger(__name__)
+    return separator
+
+
+def test_single_file_separation_fails_fast_with_original_error():
+    separator = separator_double()
+    export_error = AudioExportError("writer failed", path="bad_(Vocals).wav", backend="soundfile")
+    separator._separate_file.side_effect = export_error
+
+    with pytest.raises(AudioExportError) as raised:
+        Separator.separate(separator, "bad.wav")
+
+    assert raised.value is export_error
+
+
+def test_batch_processes_every_file_then_raises_aggregate_error():
+    separator = separator_double()
+    export_error = AudioExportError("writer failed", path="bad_(Vocals).wav", backend="soundfile")
+    separator._separate_file.side_effect = [["good_(Vocals).wav"], export_error, ["later_(Vocals).wav"]]
+
+    with pytest.raises(BatchSeparationError) as raised:
+        Separator.separate(separator, ["good.wav", "bad.wav", "later.wav"])
+
+    assert raised.value.successful_files == ["good_(Vocals).wav", "later_(Vocals).wav"]
+    assert raised.value.failures == [("bad.wav", export_error)]
+    assert "bad.wav: writer failed" in str(raised.value)
+    assert separator._separate_file.call_count == 3
+
+
+def test_directory_processes_accessible_files_before_raising_batch_error():
+    separator = separator_double()
+    export_error = AudioExportError("writer failed", path="bad_(Vocals).wav", backend="soundfile")
+    separator._separate_file.side_effect = [["good_(Vocals).wav"], export_error]
+
+    with patch("audio_separator.separator.separator.os.path.isdir", return_value=True), patch(
+        "audio_separator.separator.separator.os.walk",
+        return_value=[("/music", [], ["good.wav", "bad.wav"])],
+    ):
+        with pytest.raises(BatchSeparationError) as raised:
+            Separator.separate(separator, "/music")
+
+    assert raised.value.successful_files == ["good_(Vocals).wav"]
+    assert raised.value.failures == [("/music/bad.wav", export_error)]
+    assert separator._separate_file.call_count == 2
+
+
+def test_cleanup_failures_do_not_mask_writer_error_or_skip_later_cleanup():
+    separator = separator_double()
+    separator.chunk_duration = None
+    separator.use_autocast = False
+    separator.normalization_threshold = 0.9
+    separator.amplification_threshold = 0.0
+    separator.print_uvr_vip_message = Mock()
+    writer_error = AudioExportError("writer failed", path="bad_(Vocals).wav", backend="soundfile")
+    separator.model_instance.separate.side_effect = writer_error
+    separator.model_instance.clear_gpu_cache.side_effect = RuntimeError("cache cleanup failed")
+
+    with pytest.raises(AudioExportError) as raised:
+        Separator._separate_file(separator, "bad.wav")
+
+    assert raised.value is writer_error
+    separator.model_instance.clear_gpu_cache.assert_called_once_with()
+    separator.model_instance.clear_file_specific_paths.assert_called_once_with()
+
+
+@patch("audio_separator.separator.audio_chunking.AudioChunker")
+def test_chunked_separation_rejects_duplicate_stem_outputs(chunker_class, tmp_path):
+    separator = separator_double()
+    separator.output_dir = str(tmp_path)
+    separator.output_format = "WAV"
+    separator.chunk_duration = 10.0
+    separator.model_instance.output_dir = str(tmp_path)
+    chunker = chunker_class.return_value
+    chunker.split_audio.return_value = [str(tmp_path / "chunk_0000.wav")]
+    separator._separate_file.return_value = ["first_(Vocals).wav", "second_(Vocals).wav"]
+
+    with pytest.raises(InvalidAudioDataError, match="duplicate"):
+        Separator._process_with_chunking(separator, str(tmp_path / "input.wav"))
+
+    chunker.merge_chunks.assert_not_called()
+
+
+def test_ensemble_batch_processes_every_file_then_raises_aggregate_error():
+    separator = separator_double()
+    separator.model_filename = ["model-a.ckpt", "model-b.ckpt"]
+    export_error = AudioExportError("ensemble writer failed", path="bad_(Vocals).wav", backend="pydub")
+    separator._separate_ensemble.side_effect = [["good_(Vocals).wav"], export_error, ["later_(Vocals).wav"]]
+
+    with pytest.raises(BatchSeparationError) as raised:
+        Separator.separate(separator, ["good.wav", "bad.wav", "later.wav"])
+
+    assert raised.value.successful_files == ["good_(Vocals).wav", "later_(Vocals).wav"]
+    assert raised.value.failures == [("bad.wav", export_error)]
+    assert separator._separate_ensemble.call_count == 3
+
+
+@patch("audio_separator.separator.separator.Ensembler")
+@patch("audio_separator.separator.separator.librosa.load", return_value=(np.zeros((2, 32), dtype=np.float32), 44100))
+def test_ensemble_fallback_writer_preserves_soundfile_error(load_audio, ensembler_class, tmp_path):
+    separator = separator_double()
+    separator.model_filename = ["model-a.ckpt", "model-b.ckpt"]
+    separator.model_filenames = ["model-a.ckpt", "model-b.ckpt"]
+    separator.model_instance = None
+    separator.output_dir = str(tmp_path)
+    separator.output_format = "WAV"
+    separator.sample_rate = 44100
+    separator.normalization_threshold = 0.9
+    separator.amplification_threshold = 0.0
+    separator.ensemble_algorithm = "avg_wave"
+    separator.ensemble_weights = None
+    separator.ensemble_preset = None
+    separator._separate_file.return_value = ["input_(Vocals).wav"]
+    ensembler_class.return_value.ensemble.return_value = np.zeros((2, 32), dtype=np.float32)
+    backend_error = OSError("soundfile failed")
+
+    with patch("soundfile.write", side_effect=backend_error):
+        with pytest.raises(AudioExportError) as raised:
+            Separator._separate_ensemble(separator, "input.wav")
+
+    assert raised.value.backend == "soundfile"
+    assert raised.value.__cause__ is backend_error
+    assert raised.value.path.endswith(".wav")
+
+
+@patch("audio_separator.separator.separator.Ensembler")
+@patch("audio_separator.separator.separator.librosa.load", return_value=(np.zeros((2, 32), dtype=np.float32), 44100))
+def test_ensemble_fallback_writer_uses_wav_when_requested_format_fails(load_audio, ensembler_class, tmp_path):
+    separator = separator_double()
+    separator.model_filename = ["model-a.ckpt", "model-b.ckpt"]
+    separator.model_filenames = ["model-a.ckpt", "model-b.ckpt"]
+    separator.model_instance = None
+    separator.output_dir = str(tmp_path)
+    separator.output_format = "M4A"
+    separator.sample_rate = 44100
+    separator.normalization_threshold = 0.9
+    separator.amplification_threshold = 0.0
+    separator.ensemble_algorithm = "avg_wave"
+    separator.ensemble_weights = None
+    separator.ensemble_preset = None
+    separator._separate_file.return_value = ["input_(Vocals).wav"]
+    ensembler_class.return_value.ensemble.return_value = np.zeros((2, 32), dtype=np.float32)
+
+    def write_requested_then_wav(path, *_args, **_kwargs):
+        if str(path).endswith(".m4a"):
+            raise OSError("requested format is unsupported")
+        Path(path).write_bytes(b"wav audio")
+
+    with patch("soundfile.write", side_effect=write_requested_then_wav):
+        outputs = Separator._separate_ensemble(separator, "input.wav")
+
+    assert len(outputs) == 1
+    assert outputs[0].endswith(".wav")
+    assert Path(outputs[0]).read_bytes() == b"wav audio"
+
+
+@patch("audio_separator.separator.separator.Ensembler")
+@patch("audio_separator.separator.separator.librosa.load", return_value=(np.zeros((2, 32), dtype=np.float32), 44100))
+def test_ensemble_model_writer_failure_is_not_returned_as_success(load_audio, ensembler_class, tmp_path):
+    separator = separator_double()
+    separator.model_filename = ["model-a.ckpt", "model-b.ckpt"]
+    separator.model_filenames = ["model-a.ckpt", "model-b.ckpt"]
+    separator.output_dir = str(tmp_path)
+    separator.output_format = "WAV"
+    separator.sample_rate = 44100
+    separator.ensemble_algorithm = "avg_wave"
+    separator.ensemble_weights = None
+    separator.ensemble_preset = None
+    separator._separate_file.return_value = ["input_(Vocals).wav"]
+    ensembler_class.return_value.ensemble.return_value = np.zeros((2, 32), dtype=np.float32)
+    writer_error = AudioExportError("ensemble writer failed", path=str(tmp_path / "output.wav"), backend="pydub")
+    separator.model_instance.write_audio.side_effect = writer_error
+
+    with pytest.raises(AudioExportError) as raised:
+        Separator._separate_ensemble(separator, "input.wav")
+
+    assert raised.value is writer_error

--- a/tests/unit/test_separator_chunking.py
+++ b/tests/unit/test_separator_chunking.py
@@ -11,6 +11,7 @@ import logging
 from unittest.mock import Mock, patch, MagicMock, call
 from pydub import AudioSegment
 
+from audio_separator.separator.exceptions import InvalidAudioDataError
 from audio_separator.separator.separator import Separator
 
 
@@ -580,8 +581,8 @@ class TestSeparatorChunkingEdgeCases:
             shutil.rmtree(self.temp_dir)
 
     @patch('audio_separator.separator.audio_chunking.AudioChunker')
-    def test_empty_output_handling(self, mock_chunker_class):
-        """Test handling when a chunk produces no output files."""
+    def test_empty_chunk_output_is_rejected_because_duration_cannot_be_preserved(self, mock_chunker_class):
+        """An empty chunk output cannot preserve the stem timeline and must fail."""
         # Setup mock separator
         separator = Mock(spec=Separator)
         separator.logger = self.logger
@@ -603,20 +604,18 @@ class TestSeparatorChunkingEdgeCases:
 
         # Import and call the actual method
         from audio_separator.separator.separator import Separator as RealSeparator
-        result = RealSeparator._process_with_chunking(
-            separator,
-            os.path.join(self.temp_dir, "test.wav"),
-            custom_output_names=None
-        )
+        with pytest.raises(InvalidAudioDataError, match="no stems"):
+            RealSeparator._process_with_chunking(
+                separator,
+                os.path.join(self.temp_dir, "test.wav"),
+                custom_output_names=None
+            )
 
-        # Should return empty list
-        assert len(result) == 0
-        # merge_chunks should not be called
-        assert mock_chunker.merge_chunks.call_count == 0
+        mock_chunker.merge_chunks.assert_not_called()
 
     @patch('audio_separator.separator.audio_chunking.AudioChunker')
-    def test_inconsistent_stem_count_across_chunks(self, mock_chunker_class):
-        """Test handling when different chunks produce different stem counts."""
+    def test_missing_stem_chunk_is_rejected_because_duration_cannot_be_preserved(self, mock_chunker_class):
+        """A missing stem chunk would shorten its timeline and must fail before merge."""
         # Setup mock separator
         separator = Mock(spec=Separator)
         separator.logger = self.logger
@@ -648,15 +647,14 @@ class TestSeparatorChunkingEdgeCases:
 
         # Import and call the actual method
         from audio_separator.separator.separator import Separator as RealSeparator
-        result = RealSeparator._process_with_chunking(
-            separator,
-            os.path.join(self.temp_dir, "test.wav"),
-            custom_output_names=None
-        )
+        with pytest.raises(InvalidAudioDataError, match="missing stem"):
+            RealSeparator._process_with_chunking(
+                separator,
+                os.path.join(self.temp_dir, "test.wav"),
+                custom_output_names=None
+            )
 
-        # Should handle inconsistency gracefully
-        # Vocals should have 2 chunks, Instrumental should have 1 chunk
-        assert len(result) == 2
+        mock_chunker.merge_chunks.assert_not_called()
 
     @patch('audio_separator.separator.audio_chunking.AudioChunker')
     def test_filename_without_stem_pattern(self, mock_chunker_class):


### PR DESCRIPTION
## Summary

Make audio output results reliable by separating audio-data validity from application-specific silence policy.

Before this change, stems with a peak below the hard-coded `1e-6` threshold were skipped without creating a file. Several pydub, FFmpeg, soundfile, and filesystem errors were also logged and swallowed. Architecture implementations still appended the planned filename, so `Separator.separate()` could report success for a file that did not exist.

This PR treats non-empty, finite audio as valid output, including completely silent and near-silent audio. Whether a stem is perceptually silent is left to the consuming application, which may use RMS, LUFS, decoded sample analysis, or product-specific criteria.

On success, every returned path refers to a fully written file.

## Background

- On December 21, 2023, [`41a5bdb`](https://github.com/nomadkaraoke/python-audio-separator/commit/41a5bdb1f916e2e9e149947db77302f2571da178) replaced direct soundfile output with pydub to support formats such as M4A. The same change introduced the `1e-6` peak check and converted `AudioSegment` and FFmpeg failures into logged early returns. Callers continued appending the planned output path regardless of whether a file had been written.
- On December 30, 2023, [`4151466`](https://github.com/nomadkaraoke/python-audio-separator/commit/41514664cddac68ecd42457243cac41484505232) added an `np.any(mix)` input check as part of an updated UVR demixing path. As a result, a valid decoded file containing frames but only zero samples was classified as “empty or not valid.”
- On June 17, 2025, [#216 (`87af20a`)](https://github.com/nomadkaraoke/python-audio-separator/commit/87af20a2b7d8d51e691b71a029ca96fa9c77102e) reintroduced a soundfile writer and copied the same near-silent early-return behavior.
- On January 16, 2026, [#256 (`10fa098`)](https://github.com/nomadkaraoke/python-audio-separator/commit/10fa098edd07152bdac27826c06fb69b2f0827a1) added file-level chunking. Each chunk is separated independently and its stem files are concatenated later.
- On March 16, 2026, [#265 (`adc5539`)](https://github.com/nomadkaraoke/python-audio-separator/commit/adc5539beeb78ef8cf21062b2a16d9aed588d769) added multi-model ensembles, whose intermediate processing also assumes returned output paths exist.

The original soundfile implementation before the pydub migration wrote silent stems normally. The `1e-6` filter was introduced as part of output-backend migration rather than as a complete public silence-result contract.

## Why remove library-level silence filtering?

A fixed peak threshold cannot determine perceptual or product-specific silence for every consumer.

Applications may use:

- RMS
- LUFS
- decoded sample analysis
- minimum duration rules
- product-specific combinations of loudness and spectral criteria

A consuming application would often need to apply its own policy even if this library filtered stems first.

Audio Separator therefore handles validity and publication:

- audio must contain frames
- samples must be finite
- channel layout must be supported
- the backend must successfully publish a file

The caller decides whether that valid file is useful or should be suppressed.

This also keeps internal processing consistent. A silent chunk still represents a real time interval, and ensemble intermediates must exist for downstream loading. Omitting those files can shorten a merged stem or leave a returned path that was never written.

For example:

```text
Expected vocals:
[10 s vocals] [10 s silence] [10 s vocals] = 30 seconds

If the silent chunk is omitted:
[10 s vocals]                [10 s vocals] = 20 seconds
```

## Changes

### Audio validation and silent output

- Preserve exact zero when amplification is enabled, avoiding division by zero.
- Reject zero-length, NaN, Inf, and structurally invalid audio with `InvalidAudioDataError`, a `ValueError` subclass.
- Treat a non-empty all-zero input as valid audio.
- Keep Demucs normalization finite when the input has zero variance.
- Write zero and near-silent stems instead of filtering them with the previous `1e-6` peak threshold.
- Support both mono and stereo writer input.

### Export failures and atomic publication

- Add `AudioExportError`, a `RuntimeError` subclass carrying:
  - the final output path
  - the backend name
  - the original exception through `__cause__`
- Write pydub, soundfile, chunk-merge, and ensemble-fallback outputs to a same-directory, same-suffix temporary file.
- Verify that the temporary output exists and is non-empty before publishing it.
- Close pydub export handles before replacement.
- Publish with `os.replace()`.
- Remove temporary files after failure.
- Preserve an existing target if replacement fails.
- Preserve an existing target's file mode and apply the current umask to new outputs.
- Preserve the existing ensemble behavior that falls back to WAV when the requested soundfile format fails.

### Public separation contract

The public exceptions are exported from `audio_separator.separator`.

- A string file path is treated as a single input and propagates failures immediately.
- A list, directory, or ensemble batch attempts all discoverable inputs.
- If any batch input fails, `BatchSeparationError` is raised after the remaining inputs are attempted.
- `BatchSeparationError.successful_files` contains outputs from inputs that completed normally.
- `BatchSeparationError.failures` contains ordered `(input_path, exception)` pairs.
- Per-file GPU and model state cleanup runs after both success and failure without masking the original separation or export error.

### Chunking and ensembles

- Reject an empty chunk result.
- Reject missing or duplicate stems across chunks instead of creating shortened or extended results.
- Keep silent chunks so the merged duration remains unchanged.
- Apply the same validation and atomic publication to the ensemble fallback writer.
- Return the real WAV path when ensemble output falls back from the requested format.

### CLI

- Exit with a non-zero status when separation raises an output or batch error.
- Do not report separation success after a writer or filesystem failure.

### Documentation

- Document that every successful returned path refers to a fully written file.
- Document that valid silent and near-silent stems are included.
- Document that silence suppression is the consuming application's responsibility.
- Document the immediate single-input and aggregated batch failure contracts.

## Compatibility and intentional behavior changes

Unchanged on success:

- `Separator.separate()` still returns `list[str]`.
- Existing relative-versus-absolute path representation is preserved.
- `output_single_stem` and `custom_output_names` behavior is preserved.
- Existing bit-depth selection remains unchanged.
- Ensemble soundfile fallback to WAV is preserved.

Intentional changes:

- Non-empty all-zero input is now treated as valid audio.
- Zero and near-silent stems now create files instead of being omitted.
- Writer and filesystem failures now raise exceptions instead of being logged and treated as success.
- A partially failed batch now raises `BatchSeparationError` after processing the remaining inputs.
- Missing or duplicate chunk stems now fail instead of producing a shortened or extended merged output.

Callers that relied on files below the previous `1e-6` peak threshold being omitted will now receive those files. Applications that want to suppress them should apply their own silence policy.

This PR does not introduce a second structured success-result API, change returned paths to always be absolute, or change remote download behavior.

## Testing

- Unit and contract suite: **341 passed, 5 skipped**

Real audio output coverage:

- zero and near-silent WAV through pydub and soundfile
- mono and stereo output
- exact frame count, sample rate, and channel count
- near-silent M4A through real FFmpeg encode and decode
- a silent intermediate chunk preserves the full merged duration
- non-empty all-zero decoded input remains valid
- Demucs receives finite normalized data for zero-variance input

Failure coverage:

- `AudioSegment` construction
- pydub / FFmpeg export
- soundfile export
- output-directory and temporary-file creation
- zero-byte backend output
- atomic replacement
- temporary-file cleanup
- existing-target preservation
- existing file mode and new-file umask handling

Public API coverage:

- single-input fail-fast behavior
- list and directory failure aggregation
- ensemble batch aggregation
- cleanup failures do not mask the original separation or export error

Architecture and intermediate-output coverage:

- MDX two-stem output
- MDXC multi-stem output
- empty, missing, and duplicate chunk stems
- ensemble model writer failure
- ensemble fallback writer failure
- requested-format failure followed by successful WAV fallback

CLI coverage:

- separation failures produce a non-zero exit status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear audio validation and export exceptions.
  * Batch and directory processing now continues after individual failures and reports a combined error summary.
  * Outputs are published safely, preventing partial or empty files.
  * Improved support for mono, stereo, silent, and near-silent audio, including uppercase file extensions.
  * CLI failures now exit cleanly with status 1.

* **Bug Fixes**
  * Improved cleanup and fallback behavior during audio processing.

* **Documentation**
  * Documented output guarantees and error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->