### PR TITLE
fix: support librosa 1 duration API

### DIFF
--- a/audio_separator/separator/common_separator.py
+++ b/audio_separator/separator/common_separator.py
@@ -289,7 +289,7 @@ class CommonSeparator:
         https://github.com/jiaaro/pydub/issues/135
         """
         # Get the duration of the input audio file
-        duration_seconds = librosa.get_duration(filename=self.audio_file_path)
+        duration_seconds = librosa.get_duration(path=self.audio_file_path)
         duration_hours = duration_seconds / 3600
         self.logger.info(f"Audio duration is {duration_hours:.2f} hours ({duration_seconds:.2f} seconds).")
 


### PR DESCRIPTION
## Root cause

A Vast validation run against a refreshed dependency stack reached `CommonSeparator.write_audio()` with librosa 1.x. `librosa.get_duration()` no longer accepts the deprecated `filename=` alias, so the duration lookup fails before the output can be written.

Use the supported `path=` keyword. This fixes compatibility at the API call site without a wrapper, fallback, or exception guard.

## Validation

- `python -m py_compile audio_separator/separator/common_separator.py`
- `git diff --check`
- one-file, one-line semantic diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio duration detection to ensure separated audio files are written successfully with updated library behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->