### PR TITLE
Fix VR output truncation at STFT boundaries

### DIFF
--- a/audio_separator/separator/architectures/vr_separator.py
+++ b/audio_separator/separator/architectures/vr_separator.py
@@ -86,6 +86,8 @@ class VRSeparator(CommonSeparator):
         self.high_end_process = arch_config.get("high_end_process", False)
         self.input_high_end_h = None
         self.input_high_end = None
+        self.model_wave_length = None
+        self.output_wave_length = None
 
         # Adjust the intensity of primary stem extraction:
         # - Ranges from -100 - 100.
@@ -155,11 +157,13 @@ class VRSeparator(CommonSeparator):
 
         self.audio_file_path = audio_file_path
         self.audio_file_base = os.path.splitext(os.path.basename(audio_file_path))[ 0]
+        self.output_wave_length = None
 
         # Detect input audio bit depth for output preservation
         try:
             import soundfile as sf
             info = sf.info(audio_file_path)
+            self.output_wave_length = math.ceil(info.frames * self.sample_rate / info.samplerate)
             self.input_audio_subtype = info.subtype
             self.logger.info(f"Input audio subtype: {self.input_audio_subtype}")
             
@@ -235,9 +239,7 @@ class VRSeparator(CommonSeparator):
 
                 self.primary_source = self.spec_to_wav(y_spec).T
                 self.logger.debug("Converting primary source spectrogram to waveform.")
-                if not self.model_samplerate == 44100:
-                    self.primary_source = librosa.resample(self.primary_source.T, orig_sr=self.model_samplerate, target_sr=44100).T
-                    self.logger.debug("Resampling primary source to 44100Hz.")
+                self.primary_source = self._prepare_source_for_output(self.primary_source)
 
             self.primary_stem_output_path = self.get_stem_output_path(self.primary_stem_name, custom_output_names)
 
@@ -253,9 +255,7 @@ class VRSeparator(CommonSeparator):
 
                 self.secondary_source = self.spec_to_wav(v_spec).T
                 self.logger.debug("Converting secondary source spectrogram to waveform.")
-                if not self.model_samplerate == 44100:
-                    self.secondary_source = librosa.resample(self.secondary_source.T, orig_sr=self.model_samplerate, target_sr=44100).T
-                    self.logger.debug("Resampling secondary source to 44100Hz.")
+                self.secondary_source = self._prepare_source_for_output(self.secondary_source)
 
             self.secondary_stem_output_path = self.get_stem_output_path(self.secondary_stem_name, custom_output_names)
 
@@ -271,6 +271,7 @@ class VRSeparator(CommonSeparator):
 
     def loading_mix(self):
         X_wave, X_spec_s = {}, {}
+        self.model_wave_length = None
 
         bands_n = len(self.model_params.param["band"])
 
@@ -288,7 +289,16 @@ class VRSeparator(CommonSeparator):
 
             if d == bands_n:  # high-end band
                 X_wave[d], _ = librosa.load(audio_file, sr=bp["sr"], mono=False, dtype=np.float32, res_type=wav_resolution)
-                X_spec_s[d] = spec_utils.wave_to_spectrogram(X_wave[d], bp["hl"], bp["n_fft"], self.model_params, band=d, is_v51_model=self.is_vr_51_model)
+                self.model_wave_length = X_wave[d].shape[-1]
+                X_spec_s[d] = spec_utils.wave_to_spectrogram(
+                    X_wave[d],
+                    bp["hl"],
+                    bp["n_fft"],
+                    self.model_params,
+                    band=d,
+                    is_v51_model=self.is_vr_51_model,
+                    pad_to_hop=True,
+                )
 
                 if not np.any(X_wave[d]) and is_mp3:
                     X_wave[d] = rerun_mp3(audio_file, bp["sr"])
@@ -297,7 +307,15 @@ class VRSeparator(CommonSeparator):
                     X_wave[d] = np.asarray([X_wave[d], X_wave[d]])
             else:  # lower bands
                 X_wave[d] = librosa.resample(X_wave[d + 1], orig_sr=self.model_params.param["band"][d + 1]["sr"], target_sr=bp["sr"], res_type=wav_resolution)
-                X_spec_s[d] = spec_utils.wave_to_spectrogram(X_wave[d], bp["hl"], bp["n_fft"], self.model_params, band=d, is_v51_model=self.is_vr_51_model)
+                X_spec_s[d] = spec_utils.wave_to_spectrogram(
+                    X_wave[d],
+                    bp["hl"],
+                    bp["n_fft"],
+                    self.model_params,
+                    band=d,
+                    is_v51_model=self.is_vr_51_model,
+                    pad_to_hop=True,
+                )
 
             if d == bands_n and self.high_end_process:
                 self.input_high_end_h = (bp["n_fft"] // 2 - bp["crop_stop"]) + (self.model_params.param["pre_filter_stop"] - self.model_params.param["pre_filter_start"])
@@ -381,6 +399,17 @@ class VRSeparator(CommonSeparator):
         y_spec, v_spec = postprocess(mask, X_mag, X_phase)
 
         return y_spec, v_spec
+
+    def _prepare_source_for_output(self, source):
+        """Resample a source and align it to the configured output frame count."""
+        if self.model_wave_length is not None:
+            source = librosa.util.fix_length(source, size=self.model_wave_length, axis=0)
+        if self.model_samplerate != self.sample_rate:
+            source = librosa.resample(source.T, orig_sr=self.model_samplerate, target_sr=self.sample_rate).T
+            self.logger.debug(f"Resampling source to {self.sample_rate}Hz.")
+        if self.output_wave_length is not None:
+            source = librosa.util.fix_length(source, size=self.output_wave_length, axis=0)
+        return source
 
     def spec_to_wav(self, spec):
         if self.high_end_process and isinstance(self.input_high_end, np.ndarray) and self.input_high_end_h:

--- a/audio_separator/separator/uvr_lib_v5/spec_utils.py
+++ b/audio_separator/separator/uvr_lib_v5/spec_utils.py
@@ -287,10 +287,16 @@ def combine_spectrograms(specs, mp, is_v51_model=False):
     return np.asfortranarray(spec_c)
 
 
-def wave_to_spectrogram(wave, hop_length, n_fft, mp, band, is_v51_model=False):
+def wave_to_spectrogram(wave, hop_length, n_fft, mp, band, is_v51_model=False, pad_to_hop=False):
 
     if wave.ndim == 1:
         wave = np.asfortranarray([wave, wave])
+
+    if pad_to_hop:
+        # Cover incomplete final hops with a centered frame so ISTFT does not
+        # normalize the filtered right edge against a near-zero window sum.
+        padded_length = math.ceil(wave.shape[-1] / hop_length) * hop_length
+        wave = librosa.util.fix_length(wave, size=padded_length, axis=-1)
 
     if not is_v51_model:
         if mp.param["reverse"]:

--- a/tests/unit/test_vr_audio_length.py
+++ b/tests/unit/test_vr_audio_length.py
@@ -1,0 +1,134 @@
+"""Audio boundary contracts for VR separation."""
+
+import logging
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+
+from audio_separator.separator.architectures.vr_separator import VRSeparator
+from audio_separator.separator.uvr_lib_v5 import spec_utils
+
+
+SAMPLE_RATE = 44100
+
+
+@pytest.fixture(autouse=True)
+def use_portable_vr_resampler(monkeypatch):
+    """Keep boundary tests independent of the optional libsamplerate backend."""
+    monkeypatch.setattr(spec_utils, "wav_resolution", "polyphase")
+
+
+def _make_vr_separator(tmp_path, input_audio, vr_model_param="4band_v2", high_end_process=False):
+    input_path = tmp_path / "input.wav"
+    sf.write(input_path, input_audio, SAMPLE_RATE, subtype="PCM_16")
+
+    model_path = tmp_path / "model.pth"
+    model_path.write_bytes(b"\0")
+
+    output_dir = tmp_path / "output"
+    common_config = {
+        "logger": logging.getLogger(__name__),
+        "log_level": logging.INFO,
+        "torch_device": torch.device("cpu"),
+        "torch_device_cpu": torch.device("cpu"),
+        "torch_device_mps": None,
+        "onnx_execution_provider": [],
+        "model_name": "test-vr",
+        "model_path": str(model_path),
+        "model_data": {"vr_model_param": vr_model_param, "primary_stem": "Vocals"},
+        "output_dir": str(output_dir),
+        "output_format": "WAV",
+        "output_bitrate": None,
+        "normalization_threshold": 1.0,
+        "amplification_threshold": 0.0,
+        "enable_denoise": False,
+        "output_single_stem": "Vocals",
+        "invert_using_spec": False,
+        "sample_rate": SAMPLE_RATE,
+        "use_soundfile": True,
+    }
+    separator = VRSeparator(common_config, {"high_end_process": high_end_process})
+    separator._ensure_model_loaded = Mock()
+    separator.inference_vr = lambda mix, _device, _aggressiveness: (mix, mix)
+
+    return separator, input_path, output_dir
+
+
+@pytest.mark.parametrize(
+    ("input_frames", "high_end_process"),
+    [(4080, False), (4080, True)],
+    ids=["partial-hop", "high-end-process"],
+)
+def test_vr_separation_preserves_input_length(tmp_path, input_frames, high_end_process):
+    input_audio = np.zeros((input_frames, 2), dtype=np.float32)
+    separator, input_path, output_dir = _make_vr_separator(tmp_path, input_audio, high_end_process=high_end_process)
+
+    output_files = separator.separate(str(input_path))
+
+    output_info = sf.info(output_dir / output_files[0])
+    assert output_info.frames == input_frames
+
+
+def test_vr_separation_preserves_input_length_after_output_resampling(tmp_path):
+    input_frames = 4080
+    input_audio = np.zeros((input_frames, 2), dtype=np.float32)
+    separator, input_path, output_dir = _make_vr_separator(tmp_path, input_audio, vr_model_param="1band_sr32000_hl512")
+
+    output_files = separator.separate(str(input_path))
+
+    output_info = sf.info(output_dir / output_files[0])
+    assert output_info.frames == input_frames
+
+
+def test_vr_separation_reconstructs_audio_after_last_hop_boundary(tmp_path):
+    input_frames = 4081
+    tail_frames = 240
+    tail_time = np.arange(tail_frames) / SAMPLE_RATE
+    tail_signal = 0.5 * np.sin(2 * np.pi * 440 * tail_time)
+    input_audio = np.zeros((input_frames, 2), dtype=np.float32)
+    input_audio[-tail_frames:] = tail_signal[:, np.newaxis]
+    separator, input_path, output_dir = _make_vr_separator(tmp_path, input_audio)
+
+    output_files = separator.separate(str(input_path))
+
+    output_audio, _ = sf.read(output_dir / output_files[0], dtype="float32", always_2d=True)
+    output_tail = output_audio[input_frames - tail_frames :]
+    assert output_tail.shape == (tail_frames, 2) and np.any(np.abs(output_tail) > 1e-4)
+
+
+def test_vr_separation_matches_explicit_final_hop_padding(tmp_path):
+    """Match a stable reference that explicitly pads the incomplete final hop.
+
+    For ``3band_44100``, half the FFT window is shorter than one hop. Without a
+    frame at the next hop boundary, extending ISTFT to the input length makes
+    the right edge depend on a near-zero window sum and can create a large spike.
+    The explicitly padded input supplies that frame independently; automatic
+    boundary handling should reproduce the same first ``input_frames`` samples.
+    """
+    hop_length = 512
+    input_frames = hop_length * 20 + hop_length - 1
+    time = np.arange(input_frames) / SAMPLE_RATE
+    # A high-band tone exposes the unstable edge after the model's band filters.
+    signal = 0.5 * np.sin(2 * np.pi * 18000 * time)
+    input_audio = np.column_stack([signal, signal]).astype(np.float32)
+
+    automatic_dir = tmp_path / "automatic"
+    automatic_dir.mkdir()
+    automatic_separator, automatic_input, _ = _make_vr_separator(automatic_dir, input_audio, vr_model_param="3band_44100")
+    automatic_separator.final_process = Mock()
+    automatic_separator.separate(str(automatic_input))
+    automatic_output = automatic_separator.final_process.call_args.args[1]
+
+    explicit_dir = tmp_path / "explicit"
+    explicit_dir.mkdir()
+    explicit_padding = hop_length - input_frames % hop_length
+    explicitly_padded_audio = np.pad(input_audio, ((0, explicit_padding), (0, 0)))
+    explicit_separator, explicit_input, _ = _make_vr_separator(explicit_dir, explicitly_padded_audio, vr_model_param="3band_44100")
+    explicit_separator.final_process = Mock()
+    explicit_separator.separate(str(explicit_input))
+    explicit_output = explicit_separator.final_process.call_args.args[1]
+
+    np.testing.assert_array_equal(automatic_output, explicit_output[:input_frames])


### PR DESCRIPTION
## Summary

This PR fixes VR outputs becoming shorter than their inputs when the input length is not aligned with the model's STFT hop size.

It also:

- covers incomplete final hops before STFT;
- restores the waveform to its original model-rate length;
- resamples to the configured output sample rate instead of a hard-coded 44.1 kHz;
- aligns the final output with the frame count derived from the input metadata;
- adds model-free regression tests for VR boundary handling.

## Problem

The VR path used centered STFT/ISTFT without preserving the expected waveform length.

When the input length was not divisible by the model's hop size, ISTFT inferred a length ending at the last complete hop. This truncated the end of both output stems.

For example, with `2_HP-UVR`:

```text
input:          882000 samples
hop length:        480 samples
remainder:         240 samples
output before:  881760 samples
```

At 44.1 kHz, both stems were approximately 5.44 ms shorter than the input.

## Approach

```mermaid
flowchart LR
    A["Input<br/>N samples"] --> B{"Final-hop handling"}

    B -->|"Current upstream"| C["No additional frame"]
    C --> D["ISTFT infers length"]
    D --> E["floor(N / hop) × hop"]
    E --> F["Short output<br/>tail is lost"]

    B -->|"Rejected alternative<br/>set ISTFT length only"| G["No additional frame"]
    G --> H["Force ISTFT to N samples"]
    H --> I["Right-edge window sum<br/>can approach zero"]
    I --> J["Boundary spike"]

    B -->|"This PR"| K["Pad to the next hop<br/>before STFT"]
    K --> L["Create a frame covering<br/>the original right edge"]
    L --> M["ISTFT"]
    M --> N["Trim at the model sample rate"]
    N --> O["Resample to configured output rate"]
    O --> P["Correct length<br/>stable tail"]
```

| Approach | Output length | Final boundary |
|---|---|---|
| Current upstream | Too short | Samples after the last complete hop are lost |
| Set ISTFT `length` only | Correct | Can produce a boundary spike |
| This PR | Correct | Tail is reconstructed from a fully covered STFT boundary |

## Implementation

Before STFT, the VR waveform is padded to the next hop boundary when necessary:

```text
padded length = ceil(input length / hop length) × hop length
```

This creates a centered STFT frame at or beyond the original right boundary, ensuring that the final input samples have valid window support.

Padding is applied before VR time-domain transforms such as reverse and mid/side processing. After the inverse transforms, the padding returns to the end of the waveform and can be removed safely.

After spectrogram reconstruction, the waveform is processed in this order:

1. trim to the original loaded length at the model sample rate;
2. resample to the configured output sample rate;
3. align to the output frame count derived from the input metadata.

The previous hard-coded 44.1 kHz output resampling target is replaced with the configured sample rate.

## Why setting ISTFT length alone is not sufficient

The boundary spike described here is not an existing symptom of the original truncation bug. It was found while evaluating a simpler fix that only passed the original length to ISTFT.

In `3band_44100`, half of the FFT window is shorter than one hop:

```text
n_fft:       768
n_fft / 2:   384
hop length:  512
```

If the input ends immediately before the next hop boundary, the final STFT frame does not cover the complete right edge.

With neural inference replaced by an identity function, a boundary regression experiment produced the following results.

### 18 kHz sine wave

For a sine wave ending at `hop - 1`, the length-only ISTFT implementation increased the pre-export peak from approximately `0.23` to `99.94`.

### Real audio cut at the same boundary condition

```text
input tail peak:          approximately 0.22
length-only ISTFT peak:  approximately 0.92
padded STFT peak:        approximately 0.22
```

A 20-second real-audio sample used for manual validation did not exhibit this spike under `3band_44100`:

```text
882000 % 512 = 336
n_fft / 2    = 384
```

Its remainder fits within half of the FFT window. The same sample still reproduced the original truncation with `2_HP-UVR`, but it did not trigger the boundary spike found in the rejected length-only implementation.

For this reason, this PR pads before STFT rather than only forcing ISTFT to return the original length.

## Regression tests

The tests exercise the public `VRSeparator.separate()` path with real STFT, ISTFT, multiband resampling, and WAV output.

Only model loading and neural inference are replaced, so the tests do not require a model download or GPU.

The added cases cover:

- input ending partway through an STFT hop;
- the `high_end_process` reconstruction path;
- final output resampling from a 32 kHz VR model;
- recovering non-zero audio after the last complete hop;
- matching an explicitly padded stable boundary reference.

The boundary test does not assume an absolute peak or gain limit.

```python
automatic_output = separate(input_audio)

explicitly_padded_audio = np.pad(input_audio, ...)
explicit_output = separate(explicitly_padded_audio)

np.testing.assert_array_equal(
    automatic_output,
    explicit_output[:input_frames],
)
```

This verifies that automatic boundary handling exactly matches the result produced when the same zero-padding is supplied explicitly.

It does not assume that:

- a separated stem can never exceed the mixture peak;
- the final hop must have lower gain than the preceding signal;
- output peaks or gains must remain below an arbitrary fixed threshold.

The observed maximum difference between automatic and explicit padding was `0.0`.

## Validation

### Automated tests

```text
tests/unit:     554 passed, 4 skipped
tests/contract:  20 passed
```

### Additional checks

- Exercised all 26 bundled VR model-parameter configurations.
- Verified aligned STFT frame grids across all bands.
- Verified finite reconstructed output.
- Verified reverse, mid/side, and VR 5.1 round trips with maximum error below `1e-6`.
- Ran a real `2_HP-UVR.pth` separation on the same 20-second real-audio sample.

Real-model result:

```text
Input:        882000 samples / 20.000000 s
Instrumental: 882000 samples / 20.000000 s
Vocals:       882000 samples / 20.000000 s
```

The recovered final 240 samples contain non-zero separated audio rather than appended silence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio separation at the end of tracks, including files whose lengths do not align with processing-hop boundaries.
  * Preserved input audio length more reliably across high-end processing and output resampling.
  * Corrected output resampling to honor the configured sample rate.
  * Improved reconstruction quality near track boundaries by applying consistent waveform padding and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->