### PR TITLE
fix: validate non-RoFormer MDXC overlap

### DIFF
--- a/audio_separator/separator/architectures/mdxc_separator.py
+++ b/audio_separator/separator/architectures/mdxc_separator.py
@@ -585,6 +585,8 @@ class MDXCSeparator(CommonSeparator):
             self.logger.debug(f"Chunk size: {chunk_size}")
 
             hop_size = chunk_size // self.overlap
+            if hop_size <= 0:
+                raise ValueError(f"MDXC overlap ({self.overlap}) must not exceed chunk size ({chunk_size})")
             self.logger.debug(f"Hop size: {hop_size}")
 
             mix_shape = mix.shape[1]

--- a/audio_separator/utils/cli.py
+++ b/audio_separator/utils/cli.py
@@ -147,7 +147,7 @@ def main():
 
     mdxc_segment_size_help = "Larger consumes more resources, but may give better results (default: %(default)s). Example: --mdxc_segment_size=256"
     mdxc_override_model_segment_size_help = "Override model default segment size instead of using the model default value. Example: --mdxc_override_model_segment_size"
-    mdxc_overlap_help = "Number of overlapping prediction windows, 2-50. Higher is better but slower (default: model config, falling back to 8). Example: --mdxc_overlap=8"
+    mdxc_overlap_help = "Positive number of overlapping prediction windows, no greater than the model chunk size. Higher is better but slower (default: model config, falling back to 8). Example: --mdxc_overlap=8"
     mdxc_batch_size_help = "Larger consumes more RAM but may process slightly faster (default: model config, falling back to 1). Example: --mdxc_batch_size=4"
     mdxc_pitch_shift_help = "Shift audio pitch by a number of semitones while processing. May improve output for deep/high vocals. (default: %(default)s). Example: --mdxc_pitch_shift=2"
 

--- a/tests/unit/test_mdxc_config.py
+++ b/tests/unit/test_mdxc_config.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pytest
 import torch
 from ml_collections import ConfigDict
@@ -71,3 +72,22 @@ def test_mdxc_null_inference_values_use_fallbacks():
 def test_mdxc_rejects_non_positive_inference_values(arch_config, inference_config, message):
     with pytest.raises(ValueError, match=message):
         _make_separator(arch_config, inference_config)
+
+
+def test_mdxc_non_roformer_rejects_overlap_larger_than_chunk_size():
+    separator = MDXCSeparator.__new__(MDXCSeparator)
+    separator.pitch_shift = 0
+    separator.is_roformer = False
+    separator.override_model_segment_size = False
+    separator.model_data_cfgdict = ConfigDict(
+        {
+            "inference": {"dim_t": 5},
+            "audio": {"hop_length": 2},
+        }
+    )
+    separator.overlap = 9
+    separator.model_run = Mock(num_target_instruments=1)
+    separator.logger = Mock()
+
+    with pytest.raises(ValueError, match=r"MDXC overlap \(9\) must not exceed chunk size \(8\)"):
+        separator.demix(np.ones((2, 16), dtype=np.float32))


### PR DESCRIPTION
## Summary

- reject non-RoFormer MDXC overlap values that would produce a zero-sized hop
- align the CLI overlap help with the actual positive-value and model chunk-size constraints
- add regression coverage for the non-RoFormer path

Follow-up to #299 and the two remaining CodeRabbit review notes.

## Testing

- full unit suite: 550 passed, 4 skipped
- verified rendered CLI help text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent invalid MDXC audio separation settings when overlap exceeds the model’s chunk size.
  * Improved error messaging for unsupported overlap configurations.

* **Documentation**
  * Updated the command-line help text to clarify valid MDXC overlap values and their relationship to chunk size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->